### PR TITLE
show the pair page's fourteen days as a list under its chart

### DIFF
--- a/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
@@ -90,6 +90,11 @@ fun PairDetailScreen(
     val series = remember(spans, now, counting, zone) {
         Stats.dailySeries(spans, zone, now, days = WINDOW_DAYS, counting = counting)
     }
+    // The same 14-day tail the chart draws, not the 30-day series it's cut from — so the list
+    // below the chart and the chart itself agree on both which days appear and what scale they're
+    // drawn to, the way StatsScreen's chart and list agree over the full 30 days.
+    val breakdown = remember(series) { dailyBreakdown(series.takeLast(PAIR_CHART_DAYS)) }
+    val chartMax = remember(series) { chartMaxMs(series.takeLast(PAIR_CHART_DAYS)) }
 
     Scaffold(
         modifier = Modifier.padding(bottom = contentPadding.calculateBottomPadding()),
@@ -245,6 +250,13 @@ fun PairDetailScreen(
                         series = series.takeLast(PAIR_CHART_DAYS),
                         label = chartLabel,
                     )
+                }
+            }
+            // The days themselves, under the chart of them and inside the same heading — the
+            // pattern StatsScreen.kt uses for its own chart and list.
+            breakdown.firstOrNull()?.first?.let { today ->
+                items(breakdown, key = { "day:${it.first}" }) { (date, ms) ->
+                    DailyBreakdownRow(date = date, ms = ms, maxMs = chartMax, today = today)
                 }
             }
             item { SectionHeader(stringResource(R.string.pair_sessions)) }

--- a/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
@@ -21,6 +21,9 @@ import it.eldavo.ylih.data.EndReason
 import it.eldavo.ylih.data.PairEntity
 import it.eldavo.ylih.data.SessionEntity
 import it.eldavo.ylih.ui.theme.YlihTheme
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -375,5 +378,93 @@ class PairDetailScreenTest {
 
         compose.onNodeWithText(text(R.string.pair_fallback_title)).assertExists()
         compose.onNodeWithText(text(R.string.pair_lifetime), substring = true).assertExists()
+    }
+
+    /**
+     * The chart can only show a shape; the list under it is where "how much did I listen
+     * yesterday, on this pair" is actually answered, mirroring `StatsScreenTest`'s equivalent
+     * assertion for the all-pairs chart.
+     */
+    @Test
+    fun `the daily breakdown names yesterday and reaches back to the first day recorded`() {
+        val pairId = seedPair()
+
+        show(pairId)
+
+        val yesterday = text(R.string.stats_yesterday)
+        scrollTo(yesterday)
+        compose.onNodeWithText(yesterday).assertExists()
+        // seedPair()'s oldest session is three days back, so the list stops there rather than
+        // running out the whole fourteen-day window on empty days.
+        val oldest = dayLabel(now - 3 * day)
+        scrollTo(oldest)
+        compose.onNodeWithText(oldest).assertExists()
+    }
+
+    /**
+     * Unlike the stats screen's own chart, this one must not fold in every other pair's history.
+     * A second pair's session lands on the same calendar day as one of this pair's own, and that
+     * day's row has to keep showing this pair's hour alone — the sum of the two is exactly what a
+     * `spansByPair` lookup gone wrong (reading every pair's spans instead of just this one's)
+     * would produce, and nothing else on the page would catch that.
+     */
+    @Test
+    fun `the daily breakdown is scoped to this pair, not every pair`() {
+        val pairId = seedPair()
+        val zone = ZoneId.systemDefault()
+        // Anchored to local noon on a day of its own, five days back, rather than to a fixed
+        // offset from `now` the way `seedPair()`'s own sessions are: a session an hour long can
+        // straddle midnight and split across two days depending on what time of day the suite
+        // happens to run, which would make the exact-hour assertion below flaky.
+        val fifthDayNoon = LocalDate.now(zone).minusDays(5).atTime(12, 0)
+            .atZone(zone).toInstant().toEpochMilli()
+        runBlocking {
+            db.sessionDao().insert(
+                SessionEntity(
+                    pairId = pairId,
+                    connectedAt = fifthDayNoon,
+                    disconnectedAt = fifthDayNoon + hour,
+                    heartbeatAt = fifthDayNoon + hour,
+                    endReason = EndReason.DISCONNECTED,
+                ),
+            )
+            val otherDeviceId = db.deviceDao().insert(
+                DeviceEntity(
+                    deviceKey = "bt:9F:00",
+                    kind = DeviceKind.BLUETOOTH,
+                    defaultName = "Other pair",
+                    firstSeenAt = now - 30 * day,
+                ),
+            )
+            val otherPairId = db.pairDao().insert(
+                PairEntity(
+                    deviceId = otherDeviceId,
+                    label = "Other pair",
+                    generation = 1,
+                    startedAt = now - 30 * day,
+                ),
+            )
+            db.sessionDao().insert(
+                SessionEntity(
+                    pairId = otherPairId,
+                    connectedAt = fifthDayNoon + hour,
+                    disconnectedAt = fifthDayNoon + hour + 5 * hour,
+                    heartbeatAt = fifthDayNoon + hour + 5 * hour,
+                ),
+            )
+        }
+
+        show(pairId)
+
+        // This pair's own session on that day is one hour long; a leak that merged the other
+        // pair's five hours in would read six instead.
+        val sharedDay = dayLabel(fifthDayNoon)
+        scrollTo(sharedDay)
+        compose.onNodeWithContentDescription("$sharedDay: ${formatHours(hour)}").assertExists()
+    }
+
+    private fun dayLabel(epochMs: Long): String {
+        val date = Instant.ofEpochMilli(epochMs).atZone(ZoneId.systemDefault()).toLocalDate()
+        return "${formatWeekday(date)} · ${formatDayLabel(date)}"
     }
 }


### PR DESCRIPTION
A bar is a proportion and nothing else: "how long did I listen yesterday, on this pair" is a question about a figure, and no bar can be read to a tenth of an hour. The stats screen answers that for all pairs together; the pair page drew the same shape and left the figure unavailable.

The rows come from the pieces that already exist for the all-pairs list — dailyBreakdown, chartMaxMs and DailyBreakdownRow — so nothing here is new logic. What is deliberate is where they are cut from: the 14-day tail of the 30-day series the chart is itself drawn from, the same expression, rather than a second walk over the history for a shorter window. That is what makes the list and the bars agree on both which days appear and what the longest one means. It also inherits the trimming rule: only the leading run of empty days is dropped, so a zero between two days that were listened to, and a zero today, are still shown as the real answers they are.

The rows sit under the chart's own label with no header of their own, and are keyed by the date as text — the sessions below them are keyed by a database id, and a lazy list holds one namespace.

The scoping test is the one worth keeping. The pair page reads spansByPair[pairId] rather than the whole window, and a lookup that lost its filter would still produce a plausible-looking list: the leak only shows up as a day that is too large. So the test puts another pair's five-hour session on the same calendar day as one of this pair's own hours and asserts the row still reads one hour, six being exactly what the broken version would print. It is anchored to local noon five days back rather than to an offset from now, because an hour-long session pinned to the current time of day can straddle midnight and split across two rows depending on when the suite happens to run.


Closes #19.
