### PR TITLE
Count playtime per charge cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,32 @@ The UI is one section on the pair page and nowhere else, absent until `pointsDra
 `ui/BarChart.kt`'s geometry was split into a keyless `drawBars` so `CycleBarChart` draws the same
 bars against an ordinal axis; `drawDailyBars` and the widget's bitmap path go through it unchanged.
 
+**Everything here is bounded except the readings themselves, and that took three goes to get
+right.** Charge cycles are the one figure in the app with no window — a thirty-day view cannot ask
+what a charge bought when the pair was new — so a decade of them is the case to design for, and each
+of these was measured rather than guessed:
+
+- **The read must not name `sessions`.** A Room flow observes every table its query mentions, and
+  the heartbeat writes to `sessions` once a minute. Joined, the read of 400,000 readings took 3.5 s
+  and re-ran every minute for as long as the pair page was open. `BatterySampleEntity` therefore
+  carries a redundant `pairId`, which makes the same read a covering scan of
+  `(pairId, at)` — 1.5 s, and only when a reading actually lands. This is the trap
+  `observeRecentSessions` and `summarizeLifetime` already exist to avoid, walked into again.
+- **The summary belongs off the main thread.** `Charge.summarize` is 173 ms over a million
+  readings, and it used to sit in a `remember` keyed on the minute clock. It is now
+  `YlihViewModel.chargeSummary`, on `Dispatchers.Default`, with the sessions reduced to spans
+  *before* `distinctUntilChanged` — a heartbeat moves nothing a span holds, so nothing recomputes.
+- **The list and the chart are capped.** Three thousand cycles is three thousand rows between the
+  chart and the sessions below it, and three thousand sub-pixel bars redrawn every frame. The rows
+  stop at `PAIR_CYCLE_ROWS`, keeping their absolute numbering; the chart averages runs of cycles
+  into at most `MAX_CYCLE_BARS` (`bucketedBars`) so the whole lifetime still fits a screen width.
+  The tiles above stay exact, because they are counted rather than drawn.
+
+What is still linear is loading the readings at all: they are the pair's whole history by design.
+At a percent per step and a cycle a day that is ~36,500 rows a year, so a decade is a second or so
+on a background thread when a reading lands. If that ever stops being acceptable the answer is a
+rolled-up `cycles` table, not a window.
+
 ### Stats and UI
 
 `stats/Stats.kt` is pure functions over `Span` (start, optional end, optional playing ms),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,8 @@ call as often as you like. It is invoked from `BootReceiver`, `MainActivity.onSt
   wired plug events are only delivered to a live process; while up it also runs `PlaybackWatcher`
   and heartbeats every minute.
 
+- **Battery, for charge cycles** — `BtBatteryReceiver`, a second manifest receiver. See below.
+
 `data/AppContainer.kt` is a hand-rolled container reached via `(context.applicationContext as
 YlihApp).container`. `YlihApp.onCreate` deliberately does almost no work — it runs on every broadcast-
 woken process start. Its one exception is `Notifications.ensureChannelAtStartup`, and that is
@@ -182,9 +184,9 @@ logic is testable.
 ### Data model
 
 `devices` (an identity as Android reports it) → `pairs` (one physical pair, the lifetime unit,
-with `generation`) → `sessions`. Retiring a pair freezes its totals; the next connection of the
-same device opens generation + 1. This is also how wired headphones work at all, since Android
-cannot tell two wired pairs apart.
+with `generation`) → `sessions` → `battery_samples`. Retiring a pair freezes its totals; the next
+connection of the same device opens generation + 1. This is also how wired headphones work at all,
+since Android cannot tell two wired pairs apart.
 
 Two gotchas in `data/Daos.kt`: `observeSummaries()` and `observeSummary(pairId)` are the same
 large aggregate query duplicated with a `WHERE` clause — change both. And `PairSummary.closedMs`
@@ -195,6 +197,71 @@ platform views of one headset report different addresses — `AudioDeviceInfo.ge
 the leading octets while the ACL broadcast gives the full MAC — so keys use the last two octets,
 which is all both APIs disclose. Getting this wrong splits one pair's hours across two rows;
 `AudioDevicesTest` pins the observed addresses.
+
+### Charge cycles
+
+`ylih · lifetime` answers "how long did these last". Charge cycles answer "how long does a charge
+last, and how has that changed" — the battery-degradation curve issue #30 asked for. A cycle is
+**a hundred percentage points used**, however many part-charges that took.
+
+Three things here are load-bearing and none of them is obvious.
+
+**Both Bluetooth receivers must be `exported="true"`, and this was found on a phone.** The Bluetooth
+stack is a separate app (uid 1002), and an implicit broadcast from another app no longer resolves a
+non-exported component of ours — AMS drops it in `SaferIntentUtils.filterNonExportedComponents`,
+*before* the `BroadcastRecord` exists, so it does not even show as a skipped receiver in `dumpsys
+activity broadcasts`. Measured on a Mi 10T running Android 16: with `exported="false"`,
+`BtConnectionReceiver` saw nothing across five Bluetooth off/on cycles while another app's exported
+receiver logged every one; flipping the attribute alone made both receivers fire on the next cycle.
+That attribute is the whole of Bluetooth-only tracking, so it was a live bug in the shipped app and
+not only a charge-cycles concern. Exporting costs nothing because these are protected broadcasts.
+
+**The broadcast is `@SystemApi` and that is fine — for reasons, not by luck.** Android has no public
+API for a headset's battery. `tracking/BatteryBroadcast.kt` writes out
+`android.bluetooth.device.action.BATTERY_LEVEL_CHANGED` and its extra, and its KDoc records the
+three facts checked against AOSP that make depending on them safe rather than hopeful:
+`RemoteDevices.sendBatteryLevelChangedBroadcast` sends it with **`BLUETOOTH_CONNECT`** as the
+receiver permission — one this app already holds, not `BLUETOOTH_PRIVILEGED`; it carries
+`FLAG_RECEIVER_INCLUDE_BACKGROUND`, which is the flag `BroadcastSkipPolicy.disallowBackgroundStart`
+reads, so it reaches a manifest receiver in a process that is not running exactly as the ACL
+broadcasts do (the stack sets identical delivery flags on both); and it is a
+`<protected-broadcast>`, so no other app can write a battery level into the database. What is *not*
+guaranteed is that a given headset produces one at all, which is why the feature is invisible until
+it does rather than being promised anywhere.
+
+**Only drain we watched is counted.** A drop counts only between two readings taken inside *one
+session* — which is why `battery_samples` is keyed on `sessionId` rather than on `pairId`, making
+the rule a property of the schema instead of a check someone can forget. Then the points drained and
+the listening credited cover the same stretches of time and the ratio between them means something.
+Counting a drop across a gap would break that twice: there is no listening to attach to it, and a
+headset charged partway through the gap reports a level that makes the drain look smaller than it
+was with nothing to say so. `stats/Charge.kt` is the whole calculation, pure and Room-free the way
+`Stats.kt` is, so `ChargeTest` is a plain JVM test; it apportions playback across a segment with the
+same even spread `Stats.dailyMs` uses across midnight, and drops a session that never measured
+playback from **both** sides of the ratio, as `Stats.counted` does.
+
+**The first reading of a session arrives before the session does.** Measured on the same phone:
+ACL_CONNECTED at 08:20:52.721, the battery broadcast at 08:20:53.131, and `BtConnectionReceiver`'s
+own row at 08:20:53.199 — 68 ms too late, so the reading was dropped. The two receivers race by
+construction, since the connect one reads the tracking mode before it writes and both hand their
+work to the same scope. `recordBatteryLevel` therefore returns whether it found an open session, and
+`BtBatteryReceiver` retries once after two seconds. This is not a rare case to tidy up later: many
+headsets report their battery only at connect, so without the retry those pairs record nothing at
+all. `SessionRepositoryTest` pins it through `BtBatteryReceiver.recordWithRetry`, whose `settleMs`
+is a parameter for exactly that — `runTest` makes the delay virtual, and the same test written
+against the real two seconds was flaky under a loaded suite.
+
+**The receiver announces nothing.** `BtBatteryReceiver` deliberately calls neither
+`onSessionsChanged` nor `onFiguresChanged`: a reading changes no figure any widget shows, and the
+heartbeat exists to bound a missed disconnect rather than to follow the battery. Three refusals in
+`SessionRepository.recordBatteryLevel` are each worth their line — a level outside 0..100 (the stack
+broadcasts -1 for "unknown" on *every* disconnect, which at face value is a drop of the whole
+battery into nothing), no open session, and an unchanged level (re-announced when a headset
+reconnects, and a zero-drain segment in the middle of a discharge if stored).
+
+The UI is one section on the pair page and nowhere else, absent until `pointsDrained > 0`.
+`ui/BarChart.kt`'s geometry was split into a keyless `drawBars` so `CycleBarChart` draws the same
+bars against an ordinal axis; `drawDailyBars` and the widget's bitmap path go through it unchanged.
 
 ### Stats and UI
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ down when. That is the whole idea — and it happens by itself, forever, on your
 - **Listening time, not just connected time** (optional), so headphones worn around your neck
   don't count as listening.
 - **Cost per hour**, if you tell it what you paid. It goes down every time you wear them.
+- **Hours per charge**, if your headphones report their battery — and how that figure has changed
+  since they were new, which is the closest thing there is to watching a battery wear out. A charge
+  cycle here is 100% of battery used, however many part-charges that took. Not every pair reports
+  its battery to Android; the ones that don't simply have no such section.
 - **The last thirty days** as a chart, with every day listed underneath.
 - **Home-screen widgets** — lifetime hours, today's total, or the thirty-day chart.
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -48,4 +48,19 @@
         <ignore regexp="src/test/" />
     </issue>
 
+    <!-- ReceiversTest dispatches the battery broadcast through the real manifest filter, because a
+         receiver the merged manifest does not carry is a feature that works in a test and nowhere
+         else. Lint sees an implicit intent matching a non-exported component of ours and says to
+         make it explicit — which is right for an intent an app really sends, and would defeat the
+         only thing this test is for.
+
+         The neighbouring ACL_CONNECTED tests do exactly the same and are not flagged: lint exempts
+         broadcasts it knows the system protects, and it does not know this one because the constant
+         is @SystemApi. It *is* a <protected-broadcast>, so the premise of the check does not hold
+         here either. Scoped to the one file, since an implicit intent anywhere else is still worth
+         being told about. See tracking/BatteryBroadcast.kt. -->
+    <issue id="UnsafeImplicitIntentLaunch">
+        <ignore regexp="src/test/java/it/eldavo/ylih/tracking/ReceiversTest.kt" />
+    </issue>
+
 </lint>

--- a/app/schemas/it.eldavo.ylih.data.YlihDatabase/4.json
+++ b/app/schemas/it.eldavo.ylih.data.YlihDatabase/4.json
@@ -1,0 +1,338 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "7eca32f0e93c68d52c8811edb53af3c5",
+    "entities": [
+      {
+        "tableName": "devices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `deviceKey` TEXT NOT NULL, `kind` TEXT NOT NULL, `defaultName` TEXT NOT NULL, `firstSeenAt` INTEGER NOT NULL, `ignored` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceKey",
+            "columnName": "deviceKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultName",
+            "columnName": "defaultName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenAt",
+            "columnName": "firstSeenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ignored",
+            "columnName": "ignored",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_devices_deviceKey",
+            "unique": true,
+            "columnNames": [
+              "deviceKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_devices_deviceKey` ON `${TABLE_NAME}` (`deviceKey`)"
+          }
+        ]
+      },
+      {
+        "tableName": "pairs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `deviceId` INTEGER NOT NULL, `label` TEXT NOT NULL, `generation` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `retiredAt` INTEGER, `retireReason` TEXT, `purchaseDate` INTEGER, `priceCents` INTEGER, FOREIGN KEY(`deviceId`) REFERENCES `devices`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "generation",
+            "columnName": "generation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "retiredAt",
+            "columnName": "retiredAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "retireReason",
+            "columnName": "retireReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "purchaseDate",
+            "columnName": "purchaseDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "priceCents",
+            "columnName": "priceCents",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pairs_deviceId",
+            "unique": false,
+            "columnNames": [
+              "deviceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pairs_deviceId` ON `${TABLE_NAME}` (`deviceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "devices",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "deviceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `pairId` INTEGER NOT NULL, `connectedAt` INTEGER NOT NULL, `disconnectedAt` INTEGER, `playingMs` INTEGER, `heartbeatAt` INTEGER NOT NULL, `endReason` TEXT, FOREIGN KEY(`pairId`) REFERENCES `pairs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pairId",
+            "columnName": "pairId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connectedAt",
+            "columnName": "connectedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "disconnectedAt",
+            "columnName": "disconnectedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playingMs",
+            "columnName": "playingMs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "heartbeatAt",
+            "columnName": "heartbeatAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endReason",
+            "columnName": "endReason",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sessions_pairId_connectedAt",
+            "unique": false,
+            "columnNames": [
+              "pairId",
+              "connectedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_pairId_connectedAt` ON `${TABLE_NAME}` (`pairId`, `connectedAt`)"
+          },
+          {
+            "name": "index_sessions_disconnectedAt",
+            "unique": false,
+            "columnNames": [
+              "disconnectedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_disconnectedAt` ON `${TABLE_NAME}` (`disconnectedAt`)"
+          },
+          {
+            "name": "index_sessions_pairId_disconnectedAt",
+            "unique": false,
+            "columnNames": [
+              "pairId",
+              "disconnectedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sessions_pairId_disconnectedAt` ON `${TABLE_NAME}` (`pairId`, `disconnectedAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "pairs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pairId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "battery_samples",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `at` INTEGER NOT NULL, `level` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "at",
+            "columnName": "at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_samples_sessionId_at",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_samples_sessionId_at` ON `${TABLE_NAME}` (`sessionId`, `at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7eca32f0e93c68d52c8811edb53af3c5')"
+    ]
+  }
+}

--- a/app/schemas/it.eldavo.ylih.data.YlihDatabase/4.json
+++ b/app/schemas/it.eldavo.ylih.data.YlihDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "7eca32f0e93c68d52c8811edb53af3c5",
+    "identityHash": "d7081a596d0acb5ea560761e50436f06",
     "entities": [
       {
         "tableName": "devices",
@@ -246,7 +246,7 @@
       },
       {
         "tableName": "battery_samples",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `at` INTEGER NOT NULL, `level` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `pairId` INTEGER NOT NULL, `at` INTEGER NOT NULL, `level` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -257,6 +257,12 @@
           {
             "fieldPath": "sessionId",
             "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pairId",
+            "columnName": "pairId",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -289,6 +295,16 @@
             ],
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_samples_sessionId_at` ON `${TABLE_NAME}` (`sessionId`, `at`)"
+          },
+          {
+            "name": "index_battery_samples_pairId_at",
+            "unique": false,
+            "columnNames": [
+              "pairId",
+              "at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_samples_pairId_at` ON `${TABLE_NAME}` (`pairId`, `at`)"
           }
         ],
         "foreignKeys": [
@@ -332,7 +348,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7eca32f0e93c68d52c8811edb53af3c5')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd7081a596d0acb5ea560761e50436f06')"
     ]
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,16 +61,46 @@
             android:foregroundServiceType="connectedDevice" />
 
         <!--
-          ACL_CONNECTED/ACL_DISCONNECTED are on the implicit-broadcast exception list, so this
-          manifest receiver still runs on Android 8+ with nothing of ours resident. The system
-          delivers these protected broadcasts to non-exported receivers.
+          ACL_CONNECTED/ACL_DISCONNECTED carry FLAG_RECEIVER_INCLUDE_BACKGROUND, so this manifest
+          receiver still runs on Android 8+ with nothing of ours resident.
+
+          exported="true", and it has to be. This used to read "false" with a comment saying the
+          system delivers protected broadcasts to non-exported receivers — which was true when it
+          was written and is not any more. The Bluetooth stack is a separate app (uid 1002), and an
+          implicit broadcast from another app no longer resolves a non-exported component of ours:
+          AMS drops it in SaferIntentUtils.filterNonExportedComponents, before the BroadcastRecord
+          exists, so it does not even appear as a skipped receiver in `dumpsys activity broadcasts`.
+
+          Measured on a Mi 10T running Android 16: with exported="false" this receiver saw nothing
+          across five Bluetooth off/on cycles while another app's *exported* receiver logged every
+          one of them; flipping this attribute alone made it fire on the next cycle. That is the
+          whole of Bluetooth-only tracking, so with it false the default mode records nothing.
+
+          Exporting costs nothing here: both actions are <protected-broadcast>, so only the system
+          may send them and no other app can forge a connection.
         -->
         <receiver
             android:name=".tracking.BtConnectionReceiver"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
                 <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+            </intent-filter>
+        </receiver>
+
+        <!--
+          The headset's own battery level, for charge cycles. The action is @SystemApi and so cannot
+          be named from the SDK, but it is a protected broadcast sent with BLUETOOTH_CONNECT as its
+          receiver permission and the same FLAG_RECEIVER_INCLUDE_BACKGROUND the ACL broadcasts
+          carry — so it reaches a manifest receiver with nothing of ours resident, exactly as they
+          do, and exported for exactly the same reason theirs is. tracking/BatteryBroadcast.kt has
+          the whole reasoning.
+        -->
+        <receiver
+            android:name=".tracking.BtBatteryReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.BATTERY_LEVEL_CHANGED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/it/eldavo/ylih/data/Daos.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/Daos.kt
@@ -238,6 +238,39 @@ interface SessionDao {
 }
 
 @Dao
+interface BatterySampleDao {
+    /**
+     * The newest reading of a session, which is the only one a fresh one has to be compared
+     * against: an unchanged level is not a new observation and must not become a row.
+     */
+    @Query("SELECT * FROM battery_samples WHERE sessionId = :sessionId ORDER BY at DESC LIMIT 1")
+    suspend fun lastFor(sessionId: Long): BatterySampleEntity?
+
+    @Insert
+    suspend fun insert(sample: BatterySampleEntity): Long
+
+    /**
+     * Every reading a pair has ever produced, oldest first — the pair page's charge cycles are a
+     * lifetime figure, so unlike the charts there is no window to bound this to.
+     *
+     * The join costs nothing: `index_battery_samples_sessionId_at` answers the lookup and
+     * `index_sessions_pairId_connectedAt` the filter.
+     */
+    @Query(
+        """
+        SELECT b.* FROM battery_samples b
+        JOIN sessions s ON s.id = b.sessionId
+        WHERE s.pairId = :pairId
+        ORDER BY b.at
+        """,
+    )
+    fun observeForPair(pairId: Long): Flow<List<BatterySampleEntity>>
+
+    @Query("SELECT * FROM battery_samples ORDER BY at")
+    suspend fun getAll(): List<BatterySampleEntity>
+}
+
+@Dao
 interface SettingsDao {
     /**
      * The whole table at once, never one setting at a time, and that is a correctness requirement

--- a/app/src/main/java/it/eldavo/ylih/data/Daos.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/Daos.kt
@@ -253,17 +253,12 @@ interface BatterySampleDao {
      * Every reading a pair has ever produced, oldest first — the pair page's charge cycles are a
      * lifetime figure, so unlike the charts there is no window to bound this to.
      *
-     * The join costs nothing: `index_battery_samples_sessionId_at` answers the lookup and
-     * `index_sessions_pairId_connectedAt` the filter.
+     * Off `battery_samples` alone, never joined to `sessions`, which is why [BatterySampleEntity]
+     * carries `pairId` at all: a Room flow observes every table its query names, and the heartbeat
+     * writes to `sessions` once a minute. `index_battery_samples_pairId_at` covers both the filter
+     * and the order, so there is no temp B-tree either.
      */
-    @Query(
-        """
-        SELECT b.* FROM battery_samples b
-        JOIN sessions s ON s.id = b.sessionId
-        WHERE s.pairId = :pairId
-        ORDER BY b.at
-        """,
-    )
+    @Query("SELECT * FROM battery_samples WHERE pairId = :pairId ORDER BY at")
     fun observeForPair(pairId: Long): Flow<List<BatterySampleEntity>>
 
     @Query("SELECT * FROM battery_samples ORDER BY at")

--- a/app/src/main/java/it/eldavo/ylih/data/Entities.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/Entities.kt
@@ -135,6 +135,45 @@ data class SessionEntity(
 )
 
 /**
+ * One battery level, as the headset reported it partway through a session.
+ *
+ * Keyed on the *session* rather than on the pair, which is what makes "only drain we actually
+ * watched" a property of the schema instead of a rule someone has to remember: two readings can
+ * only be subtracted when they belong to the same row here, and a gap in which the headphones were
+ * charged is indistinguishable from one in which they were not. The cascade is the other half —
+ * deleting a session, retiring a pair or importing over the lot takes the readings with it.
+ *
+ * How often a row lands is entirely up to the headphones, and the answer is usually "often". Most
+ * report through HFP 1.7's battery-level HF indicator, `AT+BIEV=2,<0-100>`, which carries a real
+ * percentage — observed on an ACCENTUM Plus as `EVENT_TYPE_BIEV valInt=2, valInt2=50`. BLE's
+ * battery service is the same resolution and Apple's `AT+IPHONEACCEV` moves in tens.
+ *
+ * The five-step `+CIND` indicator the stack widens to 0 / 13 / 38 / 63 / 88 / 100 is *not* this
+ * path: `batteryChargeIndicatorToPercentage` is reached only from `onAgBatteryLevelChanged`, the
+ * HFP **client** role, where the phone is the headset rather than the audio gateway. No pair of
+ * headphones takes it.
+ */
+@Entity(
+    tableName = "battery_samples",
+    foreignKeys = [
+        ForeignKey(
+            entity = SessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sessionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["sessionId", "at"])],
+)
+data class BatterySampleEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val sessionId: Long,
+    val at: Long,
+    /** Percent remaining, 0..100, exactly as the platform reported it. */
+    val level: Int,
+)
+
+/**
  * One user setting, stored as text and parsed by [SettingsStore].
  *
  * A key/value table rather than a one-row table with a column per setting: adding a setting is

--- a/app/src/main/java/it/eldavo/ylih/data/Entities.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/Entities.kt
@@ -163,11 +163,22 @@ data class SessionEntity(
             onDelete = ForeignKey.CASCADE,
         ),
     ],
-    indices = [Index(value = ["sessionId", "at"])],
+    indices = [Index(value = ["sessionId", "at"]), Index(value = ["pairId", "at"])],
 )
 data class BatterySampleEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val sessionId: Long,
+    /**
+     * The pair the session belongs to, carried here as well.
+     *
+     * Redundant — it is `sessions.pairId` for [sessionId], and a session never changes pair — and
+     * worth it for one reason: reading a pair's history through a join makes Room's flow observe
+     * `sessions` too, and the heartbeat writes to that table once a minute. Measured over 400,000
+     * readings, that re-ran a 3.5-second query every minute for as long as the pair page was open.
+     * Off this column the same read is an index scan of `(pairId, at)` with no join and no sort,
+     * and it re-runs only when a reading actually lands.
+     */
+    val pairId: Long,
     val at: Long,
     /** Percent remaining, 0..100, exactly as the platform reported it. */
     val level: Int,

--- a/app/src/main/java/it/eldavo/ylih/data/SessionRepository.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/SessionRepository.kt
@@ -135,7 +135,12 @@ class SessionRepository(
                 val open = sessions.openFor(pair.id) ?: return@withTransaction false
                 if (batterySamples.lastFor(open.id)?.level != level) {
                     batterySamples.insert(
-                        BatterySampleEntity(sessionId = open.id, at = at, level = level),
+                        BatterySampleEntity(
+                            sessionId = open.id,
+                            pairId = pair.id,
+                            at = at,
+                            level = level,
+                        ),
                     )
                 }
                 true

--- a/app/src/main/java/it/eldavo/ylih/data/SessionRepository.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/SessionRepository.kt
@@ -19,6 +19,7 @@ class SessionRepository(
     private val devices = db.deviceDao()
     private val pairs = db.pairDao()
     private val sessions = db.sessionDao()
+    private val batterySamples = db.batterySampleDao()
 
     /**
      * Serialises writes from receivers, the service and the worker, which race freely.
@@ -106,6 +107,44 @@ class SessionRepository(
             }
         }
     }
+
+    /**
+     * Files the headset's own battery level against whatever session [key] has open.
+     *
+     * Three refusals, and each of them is the difference between a charge-cycle figure and a
+     * fiction:
+     *
+     * - a level outside 0..100 is not a reading. The stack broadcasts -1 for "unknown" and -100
+     *   for "Bluetooth is off", and it sends the first of those on *every* disconnect — taken at
+     *   face value that is a 40-point drop into nothing;
+     * - with no open session there is nothing to file against, and a reading that outlived its
+     *   session would let two of them be subtracted across a gap nothing watched;
+     * - an unchanged level is not a new observation. The stack re-announces the current level when
+     *   a headset reconnects and whenever another source of it appears, and storing that would put
+     *   a zero-drain segment in the middle of a discharge.
+     *
+     * @return whether the pair had an open session to file against — false meaning "ask again",
+     *   which is a real case and not a rare one. See [it.eldavo.ylih.tracking.BtBatteryReceiver].
+     */
+    suspend fun recordBatteryLevel(key: String, level: Int, at: Long = clock.now()): Boolean =
+        mutex.withLock {
+            if (level !in 0..100) return@withLock false
+            db.withTransaction {
+                val device = devices.findByKey(key) ?: return@withTransaction false
+                val pair = pairs.activeFor(device.id) ?: return@withTransaction false
+                val open = sessions.openFor(pair.id) ?: return@withTransaction false
+                if (batterySamples.lastFor(open.id)?.level != level) {
+                    batterySamples.insert(
+                        BatterySampleEntity(sessionId = open.id, at = at, level = level),
+                    )
+                }
+                true
+            }
+        }
+
+    /** Every reading a pair has produced, oldest first. A read, so no mutex. */
+    fun observeBatterySamples(pairId: Long): Flow<List<BatterySampleEntity>> =
+        batterySamples.observeForPair(pairId)
 
     suspend fun openSessionIdFor(key: String): Long? = mutex.withLock {
         val device = devices.findByKey(key) ?: return@withLock null

--- a/app/src/main/java/it/eldavo/ylih/data/YlihDatabase.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/YlihDatabase.kt
@@ -78,14 +78,18 @@ abstract class YlihDatabase : RoomDatabase() {
                 connection.execSQL(
                     "CREATE TABLE IF NOT EXISTS `battery_samples` (" +
                         "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
-                        "`sessionId` INTEGER NOT NULL, `at` INTEGER NOT NULL, " +
-                        "`level` INTEGER NOT NULL, " +
+                        "`sessionId` INTEGER NOT NULL, `pairId` INTEGER NOT NULL, " +
+                        "`at` INTEGER NOT NULL, `level` INTEGER NOT NULL, " +
                         "FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) " +
                         "ON UPDATE NO ACTION ON DELETE CASCADE )",
                 )
                 connection.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_battery_samples_sessionId_at` " +
                         "ON `battery_samples` (`sessionId`, `at`)",
+                )
+                connection.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_battery_samples_pairId_at` " +
+                        "ON `battery_samples` (`pairId`, `at`)",
                 )
             }
         }

--- a/app/src/main/java/it/eldavo/ylih/data/YlihDatabase.kt
+++ b/app/src/main/java/it/eldavo/ylih/data/YlihDatabase.kt
@@ -14,9 +14,10 @@ import androidx.sqlite.execSQL
         DeviceEntity::class,
         PairEntity::class,
         SessionEntity::class,
+        BatterySampleEntity::class,
         SettingEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -26,6 +27,8 @@ abstract class YlihDatabase : RoomDatabase() {
     abstract fun pairDao(): PairDao
 
     abstract fun sessionDao(): SessionDao
+
+    abstract fun batterySampleDao(): BatterySampleDao
 
     abstract fun settingsDao(): SettingsDao
 
@@ -61,6 +64,33 @@ abstract class YlihDatabase : RoomDatabase() {
         }
 
         /**
+         * Adds `battery_samples` — see [BatterySampleEntity]. A new table, so no existing row is
+         * touched and nothing can be lost; every install that predates it simply has no readings
+         * and so shows no charge cycles until its headphones report one.
+         *
+         * The SQL is Room's own, down to the index name and the `ON UPDATE NO ACTION` the foreign
+         * key carries: Room compares the migrated database against the identity hash compiled into
+         * this class, and a table created even slightly differently here fails every open
+         * afterwards rather than at the moment the migration ran.
+         */
+        internal val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(connection: SQLiteConnection) {
+                connection.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `battery_samples` (" +
+                        "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`sessionId` INTEGER NOT NULL, `at` INTEGER NOT NULL, " +
+                        "`level` INTEGER NOT NULL, " +
+                        "FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE )",
+                )
+                connection.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_battery_samples_sessionId_at` " +
+                        "ON `battery_samples` (`sessionId`, `at`)",
+                )
+            }
+        }
+
+        /**
          * The [name] is a parameter only so `YlihDatabaseMigrationTest` can replay an old schema
          * through this exact function rather than through a builder of its own — a migration
          * registered somewhere else is a migration the app does not have. Nothing in the app ever
@@ -71,7 +101,7 @@ abstract class YlihDatabase : RoomDatabase() {
                 context.applicationContext,
                 YlihDatabase::class.java,
                 name,
-            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build()
     }
 }
 

--- a/app/src/main/java/it/eldavo/ylih/export/JsonBackup.kt
+++ b/app/src/main/java/it/eldavo/ylih/export/JsonBackup.kt
@@ -79,6 +79,7 @@ object JsonBackup {
     data class BatterySample(
         val id: Long,
         val sessionId: Long,
+        val pairId: Long,
         val at: Long,
         val level: Int,
     )
@@ -127,7 +128,7 @@ object JsonBackup {
                     )
                 },
                 batterySamples = batterySamples.map {
-                    BatterySample(it.id, it.sessionId, it.at, it.level)
+                    BatterySample(it.id, it.sessionId, it.pairId, it.at, it.level)
                 },
             ),
         )
@@ -193,6 +194,7 @@ object JsonBackup {
                     BatterySampleEntity(
                         id = it.id,
                         sessionId = it.sessionId,
+                        pairId = it.pairId,
                         at = it.at,
                         level = it.level,
                     ),

--- a/app/src/main/java/it/eldavo/ylih/export/JsonBackup.kt
+++ b/app/src/main/java/it/eldavo/ylih/export/JsonBackup.kt
@@ -1,6 +1,7 @@
 package it.eldavo.ylih.export
 
 import androidx.room.withTransaction
+import it.eldavo.ylih.data.BatterySampleEntity
 import it.eldavo.ylih.data.DeviceEntity
 import it.eldavo.ylih.data.DeviceKind
 import it.eldavo.ylih.data.EndReason
@@ -44,6 +45,8 @@ object JsonBackup {
          * behaviour every backup had until now.
          */
         val settings: List<Setting> = emptyList(),
+        /** Defaulted for the same reason [settings] is: an older file simply has no readings. */
+        val batterySamples: List<BatterySample> = emptyList(),
     )
 
     @Serializable
@@ -73,6 +76,14 @@ object JsonBackup {
     )
 
     @Serializable
+    data class BatterySample(
+        val id: Long,
+        val sessionId: Long,
+        val at: Long,
+        val level: Int,
+    )
+
+    @Serializable
     data class Session(
         val id: Long,
         val pairId: Long,
@@ -94,6 +105,7 @@ object JsonBackup {
         val devices = db.deviceDao().getAll()
         val pairs = db.pairDao().getAll()
         val sessions = db.sessionDao().getAll()
+        val batterySamples = db.batterySampleDao().getAll()
         val settings = db.settingsDao().getAll()
         json.encodeToString(
             Backup(
@@ -113,6 +125,9 @@ object JsonBackup {
                         it.id, it.pairId, it.connectedAt, it.disconnectedAt,
                         it.playingMs, it.heartbeatAt, it.endReason?.name,
                     )
+                },
+                batterySamples = batterySamples.map {
+                    BatterySample(it.id, it.sessionId, it.at, it.level)
                 },
             ),
         )
@@ -167,6 +182,19 @@ object JsonBackup {
                         playingMs = it.playingMs,
                         heartbeatAt = it.heartbeatAt,
                         endReason = EndReason.parse(it.endReason),
+                    ),
+                )
+            }
+            // After the sessions, and not before: every reading names the session it was taken in
+            // and the foreign key is checked as each row lands.
+            val batterySamples = db.batterySampleDao()
+            backup.batterySamples.forEach {
+                batterySamples.insert(
+                    BatterySampleEntity(
+                        id = it.id,
+                        sessionId = it.sessionId,
+                        at = it.at,
+                        level = it.level,
                     ),
                 )
             }

--- a/app/src/main/java/it/eldavo/ylih/stats/Charge.kt
+++ b/app/src/main/java/it/eldavo/ylih/stats/Charge.kt
@@ -1,0 +1,195 @@
+package it.eldavo.ylih.stats
+
+/** One battery level a headset reported, and the session it was reported inside. */
+data class Reading(val sessionId: Long, val at: Long, val level: Int)
+
+/**
+ * A hundred percentage points of drain, and the listening they bought.
+ *
+ * A charge cycle here is *a hundred points used*, not a discharge from full: five 100 → 80 evenings
+ * are one cycle, which is both how battery wear is actually counted and the definition the feature
+ * was asked for with.
+ */
+data class Cycle(val startAt: Long, val endAt: Long, val countedMs: Long)
+
+/**
+ * What a pair's readings add up to. [cycles] are the completed ones, oldest first — the series
+ * whose shape answers "is this battery getting worse".
+ */
+data class ChargeSummary(
+    val cycles: List<Cycle>,
+    /** Every point of drain observed, the part-finished cycle at the end included. */
+    val pointsDrained: Int,
+    val countedMs: Long,
+    /** Points into the cycle currently in progress; `0` when the last one landed exactly. */
+    val partialPoints: Int,
+) {
+    val hasData: Boolean get() = pointsDrained > 0
+
+    /**
+     * Time one full cycle buys, over every point observed rather than over the completed cycles
+     * alone. A pair one and four fifths of the way through its second cycle would otherwise report
+     * from its first one for months, and the whole point of the figure is that it moves.
+     */
+    val msPerCycle: Long
+        get() = if (pointsDrained <= 0) 0L else countedMs * POINTS_PER_CYCLE / pointsDrained
+
+    val cyclesFraction: Double get() = pointsDrained.toDouble() / POINTS_PER_CYCLE
+}
+
+/** A hundred points used. */
+const val POINTS_PER_CYCLE = 100
+
+/**
+ * Charge cycles out of battery readings — pure functions over [Reading] and [Span], decoupled from
+ * Room the way [Stats] is, so the arithmetic runs as a plain JVM test.
+ *
+ * The rule the whole file rests on: **a drop counts only between two readings taken inside one
+ * session.** Then the points drained and the listening credited cover exactly the same stretches of
+ * time, and the ratio between them means something. Counting a drop across a gap would break that
+ * twice over — there is no listening to attach to it, and a headset charged partway through the gap
+ * reports a level that makes the drain look smaller than it was, with nothing to say so.
+ */
+object Charge {
+
+    /** One stretch between two readings over which the battery fell. */
+    private data class Segment(
+        val startAt: Long,
+        val endAt: Long,
+        val points: Int,
+        val creditMs: Long,
+    )
+
+    /**
+     * @param spans the session behind each reading, needed only to apportion playback.
+     * @param now for the open session's length; every closed one carries its own end.
+     */
+    fun summarize(
+        readings: List<Reading>,
+        spans: Map<Long, Span>,
+        now: Long,
+        counting: Counting = Counting.CONNECTED,
+    ): ChargeSummary {
+        val segments = segments(readings, spans, now, counting)
+
+        val cycles = mutableListOf<Cycle>()
+        var totalPoints = 0
+        var totalMs = 0L
+        // The cycle being filled: null start until the first points land in it, so a cycle begins
+        // where drain begins rather than where the previous one happened to end.
+        var bucketStart: Long? = null
+        var bucketPoints = 0
+        var bucketMs = 0L
+
+        for (segment in segments) {
+            totalPoints += segment.points
+            totalMs += segment.creditMs
+
+            var cursorAt = segment.startAt
+            var remainingPoints = segment.points
+            var remainingMs = segment.creditMs
+            var remainingSpan = segment.endAt - segment.startAt
+
+            // A segment can be a hundred points on its own — a headset that reports once at 100 and
+            // next at 0 — so this fills a bucket rather than assuming it only tops one up. It can
+            // never run more than twice: a hundred points is the most one segment can carry.
+            while (bucketPoints + remainingPoints >= POINTS_PER_CYCLE) {
+                val take = POINTS_PER_CYCLE - bucketPoints
+                val takeMs = remainingMs * take / remainingPoints
+                val takeSpan = remainingSpan * take / remainingPoints
+                val boundaryAt = cursorAt + takeSpan
+                cycles += Cycle(
+                    startAt = bucketStart ?: cursorAt,
+                    endAt = boundaryAt,
+                    countedMs = bucketMs + takeMs,
+                )
+                remainingPoints -= take
+                remainingMs -= takeMs
+                remainingSpan -= takeSpan
+                cursorAt = boundaryAt
+                bucketStart = null
+                bucketPoints = 0
+                bucketMs = 0L
+            }
+
+            if (remainingPoints > 0) {
+                if (bucketStart == null) bucketStart = cursorAt
+                bucketPoints += remainingPoints
+                bucketMs += remainingMs
+            }
+        }
+
+        return ChargeSummary(
+            cycles = cycles,
+            pointsDrained = totalPoints,
+            countedMs = totalMs,
+            partialPoints = bucketPoints,
+        )
+    }
+
+    /**
+     * The drops, oldest first.
+     *
+     * Readings are grouped by session before being paired up, which is what enforces the rule at
+     * the top of this file: the last reading of one session and the first of the next are never
+     * adjacent. A level going *up* is a charge — it ends one run and starts another, and carries no
+     * drain of its own.
+     */
+    private fun segments(
+        readings: List<Reading>,
+        spans: Map<Long, Span>,
+        now: Long,
+        counting: Counting,
+    ): List<Segment> {
+        val out = mutableListOf<Segment>()
+        for ((sessionId, group) in readings.groupBy { it.sessionId }) {
+            val span = spans[sessionId]
+            // Under PLAYBACK a session that never measured playback cannot answer the question at
+            // all, so its drain leaves both sides of the ratio — the same choice `Stats.counted`
+            // makes, and for the same reason: crediting it zero minutes would read as a battery
+            // that gave nothing back.
+            val rate = playbackRate(span, now, counting) ?: continue
+            val sorted = group.sortedBy { it.at }
+            for (i in 1 until sorted.size) {
+                val from = sorted[i - 1]
+                val to = sorted[i]
+                val points = from.level - to.level
+                if (points <= 0) continue
+                val elapsed = to.at - from.at
+                // A backwards step is a corrected clock rather than a stretch of listening; the
+                // drain is real but nothing can be credited to it, so neither side counts it.
+                if (elapsed <= 0) continue
+                out += Segment(
+                    startAt = from.at,
+                    endAt = to.at,
+                    points = points,
+                    creditMs = (elapsed * rate.first / rate.second).coerceAtLeast(0L),
+                )
+            }
+        }
+        return out.sortedBy { it.startAt }
+    }
+
+    /**
+     * How much counted time a millisecond of a session is worth, as numerator over denominator so
+     * the arithmetic stays in Long.
+     *
+     * Playback is stored as one total per session and never as *when* inside it the audio ran, so a
+     * stretch of the session gets its share of that total — the same even spread [Stats.dailyMs]
+     * makes when an overnight session is split across midnight. Null means this session cannot
+     * answer, and its drain is dropped.
+     */
+    private fun playbackRate(span: Span?, now: Long, counting: Counting): Pair<Long, Long>? =
+        when (counting) {
+            Counting.CONNECTED -> 1L to 1L
+            Counting.PLAYBACK -> {
+                if (span?.playingMs == null) {
+                    null
+                } else {
+                    val connected = Stats.durationMs(span, now)
+                    val playing = Stats.durationMs(span, now, Counting.PLAYBACK)
+                    if (connected <= 0) null else playing to connected
+                }
+            }
+        }
+}

--- a/app/src/main/java/it/eldavo/ylih/stats/Charge.kt
+++ b/app/src/main/java/it/eldavo/ylih/stats/Charge.kt
@@ -35,7 +35,41 @@ data class ChargeSummary(
         get() = if (pointsDrained <= 0) 0L else countedMs * POINTS_PER_CYCLE / pointsDrained
 
     val cyclesFraction: Double get() = pointsDrained.toDouble() / POINTS_PER_CYCLE
+
+    /**
+     * What a charge buys now against what it bought when the pair was new, as a fraction — 0.53
+     * meaning "a bit over half of what it managed then". Null until two cycles have completed,
+     * which is the same point the chart appears.
+     *
+     * Deliberately not the literal last cycle over the literal first. A single cycle is one
+     * fortnight of however the headphones happened to be used, and on coarse readings — a headset
+     * that reports in twenty-five point steps gives four segments to a discharge — one unlucky
+     * pair of cycles moves this figure further than a year of real wear does. Both ends are
+     * averaged over [comparisonWindow] instead, which is the same arithmetic with the noise taken
+     * out, and which reduces to exactly "last against first" when that is all there is.
+     */
+    val versusNew: Double?
+        get() {
+            if (cycles.size < 2) return null
+            val window = comparisonWindow
+            val first = cycles.take(window).sumOf { it.countedMs } / window
+            val last = cycles.takeLast(window).sumOf { it.countedMs } / window
+            return if (first <= 0L) null else last.toDouble() / first
+        }
+
+    /**
+     * Cycles averaged at each end for [versusNew]: a quarter of them, and never more than five.
+     *
+     * A quarter rather than a fixed number so that a young pair is not asked for history it has
+     * not got — at four cycles this is 1, and the comparison is the plain one. The two ends can
+     * never overlap, since twice a quarter is half.
+     */
+    val comparisonWindow: Int
+        get() = (cycles.size / 4).coerceIn(1, MAX_COMPARISON_CYCLES)
 }
+
+/** The most cycles [ChargeSummary.versusNew] averages at each end. */
+const val MAX_COMPARISON_CYCLES = 5
 
 /** A hundred points used. */
 const val POINTS_PER_CYCLE = 100

--- a/app/src/main/java/it/eldavo/ylih/tracking/BatteryBroadcast.kt
+++ b/app/src/main/java/it/eldavo/ylih/tracking/BatteryBroadcast.kt
@@ -1,0 +1,42 @@
+package it.eldavo.ylih.tracking
+
+/**
+ * The Bluetooth stack's battery broadcast, which the public SDK does not expose.
+ *
+ * `BluetoothDevice.ACTION_BATTERY_LEVEL_CHANGED` and its extra are `@SystemApi`, so the strings are
+ * written out here rather than referenced. Depending on a hidden name is normally the wrong answer,
+ * and the reasons it is the right one here are worth keeping, because every one of them was checked
+ * against AOSP rather than assumed:
+ *
+ * - **We are allowed to hear it.** `RemoteDevices.sendBatteryLevelChangedBroadcast` sends it as
+ *   `sendBroadcast(intent, BLUETOOTH_CONNECT, …)`. The receiver permission is one this app already
+ *   holds for the ACL broadcasts; it is not `BLUETOOTH_PRIVILEGED`, which is what would put it out
+ *   of reach.
+ * - **A manifest receiver is enough, provided it is exported.** It carries
+ *   `FLAG_RECEIVER_INCLUDE_BACKGROUND`, the flag `BroadcastSkipPolicy.disallowBackgroundStart`
+ *   reads — the same mechanism that lets [BtConnectionReceiver] run with nothing of this app
+ *   resident. The stack sets identical delivery flags on the ACL broadcast and on this one, so the
+ *   two arrive on the same terms, `android:exported` included: the sender is another app, and a
+ *   non-exported component of ours is dropped from an implicit broadcast before the
+ *   `BroadcastRecord` is even built. The manifest carries the measurement.
+ * - **Nobody can forge it.** It is declared `<protected-broadcast>` in the framework's own manifest,
+ *   so only the system may send it and no other app can write a battery level into our database —
+ *   which is also what makes exporting the receiver free of consequence.
+ *
+ * What is *not* guaranteed is that any given headset produces one. Battery reaches the stack over
+ * HFP's battery indicator, Apple's `AT+IPHONEACCEV`, or BLE's battery service, and plenty of
+ * headphones speak none of them. So this is a feature that appears when it can and is invisible
+ * otherwise — never a promise made up front.
+ */
+internal object BatteryBroadcast {
+    const val ACTION_BATTERY_LEVEL_CHANGED = "android.bluetooth.device.action.BATTERY_LEVEL_CHANGED"
+
+    const val EXTRA_BATTERY_LEVEL = "android.bluetooth.device.extra.BATTERY_LEVEL"
+
+    /**
+     * What the extra holds when there is no answer: `BATTERY_LEVEL_UNKNOWN` is -1 and
+     * `BATTERY_LEVEL_BLUETOOTH_OFF` is -100. Both are outside a percentage, so one range check
+     * covers them and anything else the platform invents later.
+     */
+    const val LEVEL_ABSENT = -1
+}

--- a/app/src/main/java/it/eldavo/ylih/tracking/BtBatteryReceiver.kt
+++ b/app/src/main/java/it/eldavo/ylih/tracking/BtBatteryReceiver.kt
@@ -1,0 +1,108 @@
+package it.eldavo.ylih.tracking
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.IntentCompat
+import it.eldavo.ylih.YlihApp
+import it.eldavo.ylih.data.SessionRepository
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+
+/**
+ * Files the headset's own battery level, which is how charge cycles are counted at all.
+ *
+ * Shaped like [BtConnectionReceiver] because it arrives on the same terms — see [BatteryBroadcast]
+ * for why a hidden action can be relied on here — and it is a manifest receiver for the same
+ * reason: the headphones report their battery a handful of times per discharge, at moments nothing
+ * of this app would otherwise be awake for.
+ *
+ * It deliberately tells [TrackingController] nothing. A battery reading changes no figure any
+ * widget shows, and the heartbeat exists to bound a missed disconnect rather than to follow the
+ * battery — re-enqueuing it here would write to WorkManager's database for a number nobody is
+ * looking at.
+ */
+class BtBatteryReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != BatteryBroadcast.ACTION_BATTERY_LEVEL_CHANGED) return
+        val level = intent.getIntExtra(
+            BatteryBroadcast.EXTRA_BATTERY_LEVEL,
+            BatteryBroadcast.LEVEL_ABSENT,
+        )
+        // Cheap enough to leave to the repository, and refused here as well so that a disconnect —
+        // which broadcasts "unknown" for every device every time — does not wake a coroutine and
+        // three queries to decide it had nothing to say.
+        if (level !in 0..100) return
+        val device = IntentCompat.getParcelableExtra(
+            intent,
+            BluetoothDevice.EXTRA_DEVICE,
+            BluetoothDevice::class.java,
+        ) ?: return
+        // The same filter sessions go through, so a watch, a car stereo or a speaker announcing its
+        // battery is dropped here rather than opening a row for a device the app does not track.
+        val identity = AudioDevices.identityOf(device) ?: return
+
+        val container = (context.applicationContext as YlihApp).container
+        val now = container.clock.now()
+        val pending = goAsync()
+        container.scope.launch {
+            try {
+                recordWithRetry(container.repository, identity.key, level, now)
+            } catch (e: Exception) {
+                // See BtConnectionReceiver: Room reports a database it could not open by cancelling
+                // the continuation, so a cancellation with the job still active is a real failure.
+                currentCoroutineContext().ensureActive()
+                Log.e(TAG, "Failed to record battery for ${identity.key}", e)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    // Not private: `companion object` is a separate class, so a private member would be reached
+    // through a synthetic accessor (lint's SyntheticAccessor).
+    internal companion object {
+        const val TAG = "BtBatteryReceiver"
+
+        /**
+         * How long to give a connect that is still being written. Measured at 68 ms on the phone
+         * below; two seconds is generous enough to cover a cold process opening Room for the first
+         * time, and short enough to stay well inside the `goAsync` window, which allows ten.
+         */
+        const val SESSION_SETTLE_MS = 2_000L
+
+        /**
+         * Files [level], and asks a second time if the session it belongs to has not been written
+         * yet.
+         *
+         * The first reading of a session normally arrives *before* the session does, and losing it
+         * would be losing the one reading many headsets ever send. Measured on a Mi 10T running
+         * Android 16: ACL_CONNECTED at 08:20:52.721, this broadcast at 08:20:53.131, and
+         * [BtConnectionReceiver]'s own row at 08:20:53.199 — 68 ms too late, and the reading was
+         * dropped. The two receivers race by construction, since that one reads the tracking mode
+         * before it writes and both hand their work to the same scope.
+         *
+         * A reading that still finds no session after the retry belongs to a device this app does
+         * not track, and is meant to be dropped.
+         *
+         * [settleMs] is a parameter so the retry can be driven in virtual time; nothing in the app
+         * passes it.
+         */
+        internal suspend fun recordWithRetry(
+            repository: SessionRepository,
+            key: String,
+            level: Int,
+            at: Long,
+            settleMs: Long = SESSION_SETTLE_MS,
+        ) {
+            if (repository.recordBatteryLevel(key, level, at)) return
+            delay(settleMs)
+            repository.recordBatteryLevel(key, level, at)
+        }
+    }
+}

--- a/app/src/main/java/it/eldavo/ylih/ui/BarChart.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/BarChart.kt
@@ -155,6 +155,24 @@ internal fun barMaxMs(values: List<Long>): Long =
     values.maxOrNull()?.coerceAtLeast(1L) ?: 1L
 
 /**
+ * At most [max] bars, by averaging runs of consecutive values when there are more.
+ *
+ * A pair used daily for a decade is some three thousand charge cycles, and three thousand bars on a
+ * phone is a bar narrower than a pixel drawn three thousand times a frame — the chart stops being
+ * readable long before it stops being drawable. Averaging keeps the shape, which is the only thing
+ * this chart is read for: whether the bars are getting shorter. The figures above it stay exact,
+ * because they are counted rather than drawn.
+ */
+internal fun bucketedBars(values: List<Long>, max: Int): List<Long> {
+    require(max > 0) { "max must be positive" }
+    if (values.size <= max) return values
+    // Rounded up, so the result can never exceed [max]; the last bucket may be short and is still
+    // an average of what is in it.
+    val size = (values.size + max - 1) / max
+    return values.chunked(size) { run -> run.sum() / run.size }
+}
+
+/**
  * The bars themselves, in whatever [DrawScope] is handed to them.
  *
  * Pulled out of the Canvas above so the home-screen chart widget can draw the same geometry into

--- a/app/src/main/java/it/eldavo/ylih/ui/BarChart.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/BarChart.kt
@@ -90,9 +90,69 @@ fun DailyBarChart(
     }
 }
 
+/**
+ * The same bars, one per completed charge cycle instead of one per day.
+ *
+ * A separate composable rather than a parameter on [DailyBarChart] because the axis is a different
+ * kind of thing: days carry dates, cycles carry an ordinal, and a cycle is only ever read against
+ * the ones on either side of it — the whole question being whether the bars get shorter.
+ */
+@Composable
+fun CycleBarChart(
+    values: List<Long>,
+    label: String,
+    firstLabel: String,
+    lastLabel: String,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.primary,
+    trackColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+) {
+    val maxMs = barMaxMs(values)
+    val peak = stringResource(R.string.chart_max, formatHours(maxMs))
+    val description = remember(label, firstLabel, lastLabel, peak) {
+        listOf(label, "$firstLabel – $lastLabel", peak).joinToString(" · ")
+    }
+    Column(modifier) {
+        Canvas(
+            Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .semantics { contentDescription = description },
+        ) {
+            drawBars(values, maxMs, barColor, trackColor)
+        }
+        Spacer(Modifier.height(4.dp))
+        // Merged away for the reason DailyBarChart's own axis row is: the description above already
+        // says the range and the peak.
+        Row(Modifier.fillMaxWidth().clearAndSetSemantics { }) {
+            Text(
+                text = firstLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = peak,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                text = lastLabel,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
 /** The scale the tallest bar means. Clamped so a window with no listening still divides. */
 internal fun chartMaxMs(series: List<Pair<LocalDate, Long>>): Long =
     series.maxOfOrNull { it.second }?.coerceAtLeast(1L) ?: 1L
+
+/** [chartMaxMs] for a series that has no dates in it. */
+internal fun barMaxMs(values: List<Long>): Long =
+    values.maxOrNull()?.coerceAtLeast(1L) ?: 1L
 
 /**
  * The bars themselves, in whatever [DrawScope] is handed to them.
@@ -106,12 +166,26 @@ internal fun DrawScope.drawDailyBars(
     maxMs: Long,
     barColor: Color,
     trackColor: Color,
+) = drawBars(series.map { it.second }, maxMs, barColor, trackColor)
+
+/**
+ * The geometry, with nothing left of what the bars are *of*.
+ *
+ * The daily chart, the widget's bitmap and the charge-cycle chart all draw exactly this; keeping it
+ * keyless is what stops a second copy of the arithmetic appearing the moment something is charted
+ * against an axis that is not a date.
+ */
+internal fun DrawScope.drawBars(
+    values: List<Long>,
+    maxMs: Long,
+    barColor: Color,
+    trackColor: Color,
 ) {
-    if (series.isEmpty()) return
-    val slot = size.width / series.size
+    if (values.isEmpty()) return
+    val slot = size.width / values.size
     val barWidth = (slot * 0.62f).coerceAtLeast(1.5f)
     val radius = CornerRadius(barWidth / 2, barWidth / 2)
-    series.forEachIndexed { index, (_, ms) ->
+    values.forEachIndexed { index, ms ->
         val left = index * slot + (slot - barWidth) / 2
         drawRoundRect(
             color = trackColor,

--- a/app/src/main/java/it/eldavo/ylih/ui/DailyBreakdown.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/DailyBreakdown.kt
@@ -59,24 +59,55 @@ fun DailyBreakdownRow(
     maxMs: Long,
     today: LocalDate,
     modifier: Modifier = Modifier,
+) = BreakdownRow(
+    title = dayName(date, today),
+    subtitle = null,
+    ms = ms,
+    maxMs = maxMs,
+    modifier = modifier,
+)
+
+/**
+ * One labelled figure with a bar under it, drawn against the scale the chart above uses.
+ *
+ * Shared with the pair page's charge cycles, which are the same shape of thing read the same way —
+ * a figure, and how it compares with the largest on screen. What differs between the two is only
+ * what the row is *called*, which is why that is all this takes.
+ */
+@Composable
+internal fun BreakdownRow(
+    title: String,
+    subtitle: String?,
+    ms: Long,
+    maxMs: Long,
+    modifier: Modifier = Modifier,
 ) {
-    val name = dayName(date, today)
     val value = formatHours(ms)
     Column(
         modifier
             .fillMaxWidth()
-            // Merged, and read day-first, for the reason `StatTile` is: the two texts are one
+            // Merged, and read title-first, for the reason `StatTile` is: the texts are one
             // figure, and unmerged they arrive as "3.4 h" and then the day it belongs to.
-            .semantics(mergeDescendants = true) { contentDescription = "$name: $value" }
+            .semantics(mergeDescendants = true) {
+                val name = listOfNotNull(title, subtitle).joinToString(" · ")
+                contentDescription = "$name: $value"
+            }
             .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Row(Modifier.fillMaxWidth()) {
             Text(
-                text = name,
+                text = title,
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f),
             )
             Text(text = value, style = MaterialTheme.typography.bodyMedium)
+        }
+        subtitle?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
         Spacer(Modifier.height(6.dp))
         Box(

--- a/app/src/main/java/it/eldavo/ylih/ui/Format.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/Format.kt
@@ -190,6 +190,16 @@ fun parsePriceCents(text: String): Long? {
     }.getOrNull()?.takeIf { it >= 0 }
 }
 
+/**
+ * Charge cycles, to a tenth.
+ *
+ * One decimal because that is what the underlying readings support: a headset reporting over HFP
+ * moves in twenty-five-point steps, so a hundredth of a cycle would be precision the number does
+ * not have. Whole cycles would be worse still — the figure would sit at "1" for months.
+ */
+fun formatCycles(value: Double): String =
+    String.format(Locale.getDefault(), "%.1f", value.coerceAtLeast(0.0))
+
 /** Cost per listening hour; three decimals because the number gets small fast. */
 fun formatPerHour(value: Double): String =
     String.format(Locale.getDefault(), "%.3f", value)

--- a/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
@@ -402,13 +402,23 @@ private fun ChargeCyclesHeader(charge: ChargeSummary) {
             modifier = Modifier.semantics { heading() },
         )
         Spacer(Modifier.height(8.dp))
-        StatRow(
-            listOf(
-                stringResource(R.string.pair_per_charge) to formatHours(charge.msPerCycle),
-                stringResource(R.string.pair_cycles) to formatCycles(charge.cyclesFraction),
-                stringResource(R.string.pair_charge_watched) to formatHours(charge.countedMs),
-            ),
+        val versusNew = charge.versusNew
+        val tiles = listOfNotNull(
+            stringResource(R.string.pair_per_charge) to formatHours(charge.msPerCycle),
+            versusNew?.let { stringResource(R.string.pair_vs_new) to formatPercent(it) },
+            stringResource(R.string.pair_cycles) to formatCycles(charge.cyclesFraction),
+            stringResource(R.string.pair_charge_watched) to formatHours(charge.countedMs),
         )
+        // Two rows of two once the comparison has something to say, rather than four tiles crushed
+        // into one row — "vs when new" is a long label and the figures beside it are not short.
+        // Until then it is the three-tile row every other block on this screen uses.
+        if (tiles.size == 4) {
+            StatRow(tiles.take(2))
+            Spacer(Modifier.height(8.dp))
+            StatRow(tiles.drop(2))
+        } else {
+            StatRow(tiles)
+        }
         // Only once there is more than one bar to compare. A single cycle drawn full height says
         // "this is the tallest one" about a series of one, which is the reading it is least able
         // to support — the figures above already report it.

--- a/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
@@ -32,12 +32,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import it.eldavo.ylih.R
 import it.eldavo.ylih.data.EndReason
 import it.eldavo.ylih.data.SessionEntity
+import it.eldavo.ylih.stats.Charge
+import it.eldavo.ylih.stats.ChargeSummary
 import it.eldavo.ylih.stats.Counting
+import it.eldavo.ylih.stats.Cycle
 import it.eldavo.ylih.stats.Stats
 import java.time.ZoneId
 
@@ -58,8 +63,10 @@ fun PairDetailScreen(
     // that moves the summary. MainActivity's `openPairFlow` records the same trap.
     val summaryFlow = remember(pairId) { viewModel.summary(pairId) }
     val sessionsFlow = remember(pairId) { viewModel.sessions(pairId) }
+    val readingsFlow = remember(pairId) { viewModel.batteryReadings(pairId) }
     val summary by summaryFlow.collectAsStateWithLifecycle(initialValue = null)
     val sessions by sessionsFlow.collectAsStateWithLifecycle(initialValue = emptyList())
+    val readings by readingsFlow.collectAsStateWithLifecycle(initialValue = emptyList())
     val spansByPair by viewModel.spansByPair.collectAsStateWithLifecycle()
     // Two clocks: [liveNow] drives the "connected for …" line and the open session's row, which
     // are the only things here meant to move every second. Everything else is derived from this
@@ -95,6 +102,18 @@ fun PairDetailScreen(
     // drawn to, the way StatsScreen's chart and list agree over the full 30 days.
     val breakdown = remember(series) { dailyBreakdown(series.takeLast(PAIR_CHART_DAYS)) }
     val chartMax = remember(series) { chartMaxMs(series.takeLast(PAIR_CHART_DAYS)) }
+    // The one figure here that is not derived from a window: charge cycles are a lifetime record,
+    // out of this pair's whole session list and every battery level it has ever reported. `now`
+    // is in the key only because an open session's playback share depends on how long it has been
+    // running; nothing else about a cycle moves with the clock.
+    val charge = remember(readings, sessions, now, counting) {
+        Charge.summarize(readings, sessions.associate { it.id to it.toSpan() }, now, counting)
+    }
+    // Newest first, like the day list, and numbered from the oldest so that a run of them reads as
+    // the history it is. The chart above them stays oldest-first: a battery getting worse is a line
+    // going down, which is only true left to right.
+    val cycleRows = remember(charge) { charge.cycles.withIndex().reversed() }
+    val cycleMax = remember(charge) { barMaxMs(charge.cycles.map { it.countedMs }) }
 
     Scaffold(
         modifier = Modifier.padding(bottom = contentPadding.calculateBottomPadding()),
@@ -242,7 +261,13 @@ fun PairDetailScreen(
 
                     Spacer(Modifier.height(24.dp))
                     val chartLabel = stringResource(R.string.pair_daily_hours_14)
-                    Text(chartLabel, style = MaterialTheme.typography.titleSmallEmphasized)
+                    // A heading, because it titles the day list below the chart as well as the
+                    // chart itself — the same one section StatsScreen makes of its own pair.
+                    Text(
+                        chartLabel,
+                        style = MaterialTheme.typography.titleSmallEmphasized,
+                        modifier = Modifier.semantics { heading() },
+                    )
                     Spacer(Modifier.height(8.dp))
                     DailyBarChart(
                         // The tail of the series already built above, rather than a second walk
@@ -257,6 +282,21 @@ fun PairDetailScreen(
             breakdown.firstOrNull()?.first?.let { today ->
                 items(breakdown, key = { "day:${it.first}" }) { (date, ms) ->
                     DailyBreakdownRow(date = date, ms = ms, maxMs = chartMax, today = today)
+                }
+            }
+            // Absent until the headphones have actually reported their battery. Plenty never do —
+            // the level reaches Android over HFP, Apple's vendor command or BLE's battery service,
+            // and a headset that speaks none of them can say nothing here. An empty section
+            // explaining that would be a permanent apology on every pair that has one.
+            if (charge.hasData) {
+                item { ChargeCyclesHeader(charge) }
+                items(cycleRows, key = { "cycle:${it.index}" }) { (index, cycle) ->
+                    BreakdownRow(
+                        title = stringResource(R.string.pair_cycle_number, index + 1),
+                        subtitle = cycleDates(cycle),
+                        ms = cycle.countedMs,
+                        maxMs = cycleMax,
+                    )
                 }
             }
             item { SectionHeader(stringResource(R.string.pair_sessions)) }
@@ -336,6 +376,49 @@ fun PairDetailScreen(
         )
     }
 }
+
+/**
+ * The charge-cycle block: what a charge is currently worth, and the chart of what it used to be.
+ *
+ * The heading titles the chart *and* the cycles listed under it — they are one section, the way the
+ * day list under the chart above is — so there is no `SectionHeader` between them.
+ */
+@Composable
+private fun ChargeCyclesHeader(charge: ChargeSummary) {
+    Column(Modifier.padding(horizontal = 16.dp)) {
+        Spacer(Modifier.height(24.dp))
+        val label = stringResource(R.string.pair_charge_cycles)
+        Text(
+            label,
+            style = MaterialTheme.typography.titleSmallEmphasized,
+            modifier = Modifier.semantics { heading() },
+        )
+        Spacer(Modifier.height(8.dp))
+        StatRow(
+            listOf(
+                stringResource(R.string.pair_per_charge) to formatHours(charge.msPerCycle),
+                stringResource(R.string.pair_cycles) to formatCycles(charge.cyclesFraction),
+                stringResource(R.string.pair_charge_watched) to formatHours(charge.countedMs),
+            ),
+        )
+        // Only once there is more than one bar to compare. A single cycle drawn full height says
+        // "this is the tallest one" about a series of one, which is the reading it is least able
+        // to support — the figures above already report it.
+        if (charge.cycles.size > 1) {
+            Spacer(Modifier.height(16.dp))
+            CycleBarChart(
+                values = charge.cycles.map { it.countedMs },
+                label = label,
+                firstLabel = stringResource(R.string.pair_cycle_number, 1),
+                lastLabel = stringResource(R.string.pair_cycle_number, charge.cycles.size),
+            )
+        }
+    }
+}
+
+/** When a cycle ran, for the line under its name. Two dates the locale writes for itself. */
+private fun cycleDates(cycle: Cycle): String =
+    "${formatDate(cycle.startAt)} – ${formatDate(cycle.endAt)}"
 
 @Composable
 private fun SessionRow(session: SessionEntity, now: Long) {

--- a/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
@@ -39,7 +39,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import it.eldavo.ylih.R
 import it.eldavo.ylih.data.EndReason
 import it.eldavo.ylih.data.SessionEntity
-import it.eldavo.ylih.stats.Charge
 import it.eldavo.ylih.stats.ChargeSummary
 import it.eldavo.ylih.stats.Counting
 import it.eldavo.ylih.stats.Cycle
@@ -48,6 +47,18 @@ import java.time.ZoneId
 
 /** Two weeks reads better on a single pair than a month of mostly-empty bars. */
 private const val PAIR_CHART_DAYS = 14
+
+/**
+ * How many charge cycles are listed under the chart of them.
+ *
+ * A cap rather than the lot, and for a reason the day list does not have: the days are already
+ * bounded by their window, while cycles accumulate for the life of the pair. Listing every one
+ * would put an unbounded scroll between the chart and the sessions below it.
+ */
+private const val PAIR_CYCLE_ROWS = 12
+
+/** Bars the cycle chart draws at most; beyond this, runs of cycles are averaged together. */
+private const val MAX_CYCLE_BARS = 40
 
 @Composable
 fun PairDetailScreen(
@@ -63,10 +74,10 @@ fun PairDetailScreen(
     // that moves the summary. MainActivity's `openPairFlow` records the same trap.
     val summaryFlow = remember(pairId) { viewModel.summary(pairId) }
     val sessionsFlow = remember(pairId) { viewModel.sessions(pairId) }
-    val readingsFlow = remember(pairId) { viewModel.batteryReadings(pairId) }
+    val chargeFlow = remember(pairId) { viewModel.chargeSummary(pairId) }
     val summary by summaryFlow.collectAsStateWithLifecycle(initialValue = null)
     val sessions by sessionsFlow.collectAsStateWithLifecycle(initialValue = emptyList())
-    val readings by readingsFlow.collectAsStateWithLifecycle(initialValue = emptyList())
+    val charge by chargeFlow.collectAsStateWithLifecycle(initialValue = null)
     val spansByPair by viewModel.spansByPair.collectAsStateWithLifecycle()
     // Two clocks: [liveNow] drives the "connected for …" line and the open session's row, which
     // are the only things here meant to move every second. Everything else is derived from this
@@ -102,18 +113,15 @@ fun PairDetailScreen(
     // drawn to, the way StatsScreen's chart and list agree over the full 30 days.
     val breakdown = remember(series) { dailyBreakdown(series.takeLast(PAIR_CHART_DAYS)) }
     val chartMax = remember(series) { chartMaxMs(series.takeLast(PAIR_CHART_DAYS)) }
-    // The one figure here that is not derived from a window: charge cycles are a lifetime record,
-    // out of this pair's whole session list and every battery level it has ever reported. `now`
-    // is in the key only because an open session's playback share depends on how long it has been
-    // running; nothing else about a cycle moves with the clock.
-    val charge = remember(readings, sessions, now, counting) {
-        Charge.summarize(readings, sessions.associate { it.id to it.toSpan() }, now, counting)
-    }
     // Newest first, like the day list, and numbered from the oldest so that a run of them reads as
-    // the history it is. The chart above them stays oldest-first: a battery getting worse is a line
-    // going down, which is only true left to right.
-    val cycleRows = remember(charge) { charge.cycles.withIndex().reversed() }
-    val cycleMax = remember(charge) { barMaxMs(charge.cycles.map { it.countedMs }) }
+    // the history it is — cycle 137 stays cycle 137 however few of them are listed. Only the most
+    // recent are: a pair worn daily for a decade has some three thousand cycles, and a list of
+    // those would bury the session list under it and never end. The chart carries the whole
+    // lifetime, which is where the shape is read anyway.
+    val cycleRows = remember(charge) {
+        charge?.cycles.orEmpty().withIndex().reversed().take(PAIR_CYCLE_ROWS)
+    }
+    val cycleMax = remember(cycleRows) { barMaxMs(cycleRows.map { it.value.countedMs }) }
 
     Scaffold(
         modifier = Modifier.padding(bottom = contentPadding.calculateBottomPadding()),
@@ -288,8 +296,8 @@ fun PairDetailScreen(
             // the level reaches Android over HFP, Apple's vendor command or BLE's battery service,
             // and a headset that speaks none of them can say nothing here. An empty section
             // explaining that would be a permanent apology on every pair that has one.
-            if (charge.hasData) {
-                item { ChargeCyclesHeader(charge) }
+            charge?.takeIf { it.hasData }?.let { cycles ->
+                item { ChargeCyclesHeader(cycles) }
                 items(cycleRows, key = { "cycle:${it.index}" }) { (index, cycle) ->
                     BreakdownRow(
                         title = stringResource(R.string.pair_cycle_number, index + 1),
@@ -406,8 +414,13 @@ private fun ChargeCyclesHeader(charge: ChargeSummary) {
         // to support — the figures above already report it.
         if (charge.cycles.size > 1) {
             Spacer(Modifier.height(16.dp))
+            // Every cycle the pair has ever been through, averaged into at most [MAX_CYCLE_BARS]
+            // bars so that a decade of them still draws — and still reads — in one screen width.
+            val bars = remember(charge) {
+                bucketedBars(charge.cycles.map { it.countedMs }, MAX_CYCLE_BARS)
+            }
             CycleBarChart(
-                values = charge.cycles.map { it.countedMs },
+                values = bars,
                 label = label,
                 firstLabel = stringResource(R.string.pair_cycle_number, 1),
                 lastLabel = stringResource(R.string.pair_cycle_number, charge.cycles.size),

--- a/app/src/main/java/it/eldavo/ylih/ui/YlihViewModel.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/YlihViewModel.kt
@@ -11,12 +11,14 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import it.eldavo.ylih.R
 import it.eldavo.ylih.YlihApp
+import it.eldavo.ylih.data.BatterySampleEntity
 import it.eldavo.ylih.data.DeviceEntity
 import it.eldavo.ylih.data.PairSummary
 import it.eldavo.ylih.data.SessionEntity
 import it.eldavo.ylih.export.JsonBackup
 import it.eldavo.ylih.runCatchingCancellable
 import it.eldavo.ylih.stats.Counting
+import it.eldavo.ylih.stats.Reading
 import it.eldavo.ylih.stats.Span
 import it.eldavo.ylih.stats.Summary
 import it.eldavo.ylih.widget.refreshWidgets
@@ -141,6 +143,18 @@ class YlihViewModel(app: Application) : AndroidViewModel(app) {
 
     fun sessions(pairId: Long): Flow<List<SessionEntity>> =
         container.repository.observeSessionsFor(pairId)
+
+    /**
+     * Every battery level this pair ever reported, oldest first.
+     *
+     * Unwindowed, unlike [recentSessions], because charge cycles are a lifetime figure — the
+     * question is what a charge bought when the pair was new against what it buys now, and a
+     * thirty-day window cannot ask it. The table only grows when the headphones say something new,
+     * so this is bounded by how talkative they are rather than by how long the app has run.
+     */
+    fun batteryReadings(pairId: Long): Flow<List<Reading>> =
+        container.repository.observeBatterySamples(pairId)
+            .map { samples -> samples.map { it.toReading() } }
 
     /**
      * False on the Play build until Bluetooth access is granted — see `Distribution`.
@@ -299,6 +313,8 @@ class YlihViewModel(app: Application) : AndroidViewModel(app) {
 }
 
 fun SessionEntity.toSpan(): Span = Span(connectedAt, disconnectedAt, playingMs)
+
+fun BatterySampleEntity.toReading(): Reading = Reading(sessionId, at, level)
 
 /**
  * The lifetime figure a pair's card and the ranking show, straight off the aggregate rather than

--- a/app/src/main/java/it/eldavo/ylih/ui/YlihViewModel.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/YlihViewModel.kt
@@ -17,11 +17,14 @@ import it.eldavo.ylih.data.PairSummary
 import it.eldavo.ylih.data.SessionEntity
 import it.eldavo.ylih.export.JsonBackup
 import it.eldavo.ylih.runCatchingCancellable
+import it.eldavo.ylih.stats.Charge
+import it.eldavo.ylih.stats.ChargeSummary
 import it.eldavo.ylih.stats.Counting
 import it.eldavo.ylih.stats.Reading
 import it.eldavo.ylih.stats.Span
 import it.eldavo.ylih.stats.Summary
 import it.eldavo.ylih.widget.refreshWidgets
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -30,7 +33,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
@@ -145,16 +151,29 @@ class YlihViewModel(app: Application) : AndroidViewModel(app) {
         container.repository.observeSessionsFor(pairId)
 
     /**
-     * Every battery level this pair ever reported, oldest first.
+     * This pair's charge cycles, worked out off the main thread.
      *
-     * Unwindowed, unlike [recentSessions], because charge cycles are a lifetime figure — the
-     * question is what a charge bought when the pair was new against what it buys now, and a
-     * thirty-day window cannot ask it. The table only grows when the headphones say something new,
-     * so this is bounded by how talkative they are rather than by how long the app has run.
+     * The readings themselves are unwindowed, unlike [recentSessions], because charge cycles are a
+     * lifetime figure: the question is what a charge bought when the pair was new against what it
+     * buys now, and a thirty-day window cannot ask it. That makes the walk over them the one piece
+     * of arithmetic in this app whose cost grows without bound — measured at 173 ms for a million
+     * readings — so it belongs here rather than in a `remember` on the pair page, where it used to
+     * sit keyed on the minute clock and so re-ran on the main thread every sixty seconds.
+     *
+     * The sessions are reduced to their spans *before* [distinctUntilChanged], which is what keeps
+     * the heartbeat out of this: it writes to `sessions` once a minute and moves nothing this
+     * summary reads, so the spans compare equal and nothing recomputes.
      */
-    fun batteryReadings(pairId: Long): Flow<List<Reading>> =
-        container.repository.observeBatterySamples(pairId)
+    fun chargeSummary(pairId: Long): Flow<ChargeSummary> {
+        val spans = container.repository.observeSessionsFor(pairId)
+            .map { sessions -> sessions.associate { it.id to it.toSpan() } }
+            .distinctUntilChanged()
+        val readings = container.repository.observeBatterySamples(pairId)
             .map { samples -> samples.map { it.toReading() } }
+        return combine(readings, spans, counting) { byTime, bySession, mode ->
+            Charge.summarize(byTime, bySession, container.clock.now(), mode)
+        }.flowOn(Dispatchers.Default)
+    }
 
     /**
      * False on the Play build until Bluetooth access is granted — see `Distribution`.

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">per laai</string>
     <string name="pair_cycles">siklusse</string>
     <string name="pair_charge_watched">waargeneem</string>
+    <string name="pair_vs_new">teenoor nuut</string>
     <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">hernoem paar</string>
     <string name="pair_rename_label">naam</string>

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">per uur</string>
     <string name="pair_bought">gekoop</string>
     <string name="pair_daily_hours_14">daaglikse ure (14 dae)</string>
+    <string name="pair_charge_cycles">laaisiklusse</string>
+    <string name="pair_per_charge">per laai</string>
+    <string name="pair_cycles">siklusse</string>
+    <string name="pair_charge_watched">waargeneem</string>
+    <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">hernoem paar</string>
     <string name="pair_rename_label">naam</string>
     <string name="pair_retire_title">pensioneer hierdie paar</string>

--- a/app/src/main/res/values-ak/strings.xml
+++ b/app/src/main/res/values-ak/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ahoɔden baako</string>
     <string name="pair_cycles">nsakraeɛ</string>
     <string name="pair_charge_watched">wɔahwɛ</string>
+    <string name="pair_vs_new">sɛ ɛyɛ foforɔ</string>
     <string name="pair_cycle_number">nsakraeɛ %1$d</string>
     <string name="pair_rename_title">sesa sua din</string>
     <string name="pair_rename_label">din</string>

--- a/app/src/main/res/values-ak/strings.xml
+++ b/app/src/main/res/values-ak/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">a manim baako so</string>
     <string name="pair_bought">agu</string>
     <string name="pair_daily_hours_14">manim bere nna (nnɔnnum 14)</string>
+    <string name="pair_charge_cycles">ahoɔden nsakraeɛ</string>
+    <string name="pair_per_charge">ahoɔden baako</string>
+    <string name="pair_cycles">nsakraeɛ</string>
+    <string name="pair_charge_watched">wɔahwɛ</string>
+    <string name="pair_cycle_number">nsakraeɛ %1$d</string>
     <string name="pair_rename_title">sesa sua din</string>
     <string name="pair_rename_label">din</string>
     <string name="pair_retire_title">twali sua yi so</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -100,6 +100,7 @@
     <string name="pair_per_charge">በአንድ ሙሌት</string>
     <string name="pair_cycles">ዑደቶች</string>
     <string name="pair_charge_watched">የተመለከተ</string>
+    <string name="pair_vs_new">ከአዲስ ጋር</string>
     <string name="pair_cycle_number">ዑደት %1$d</string>
     <string name="pair_rename_title">ጥንድ እንደገና ሰይም</string>
     <string name="pair_rename_label">ስም</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -96,6 +96,11 @@
     <string name="pair_per_hour">በሰዓት</string>
     <string name="pair_bought">ገዛ</string>
     <string name="pair_daily_hours_14">ዕለታዊ ሰዓታት (14 ቀናት)</string>
+    <string name="pair_charge_cycles">የኃይል ሙሌት ዑደቶች</string>
+    <string name="pair_per_charge">በአንድ ሙሌት</string>
+    <string name="pair_cycles">ዑደቶች</string>
+    <string name="pair_charge_watched">የተመለከተ</string>
+    <string name="pair_cycle_number">ዑደት %1$d</string>
     <string name="pair_rename_title">ጥንድ እንደገና ሰይም</string>
     <string name="pair_rename_label">ስም</string>
     <string name="pair_retire_title">ይህን ጥንድ ከስራ ተወቅ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_per_charge">لكل شحنة</string>
     <string name="pair_cycles">دورات</string>
     <string name="pair_charge_watched">مرصود</string>
+    <string name="pair_vs_new">مقارنة بالجديد</string>
     <string name="pair_cycle_number">الدورة %1$d</string>
     <string name="pair_rename_title">إعادة تسمية الزوج</string>
     <string name="pair_rename_label">الاسم</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -99,6 +99,11 @@
     <string name="pair_per_hour">في الساعة</string>
     <string name="pair_bought">الشراء</string>
     <string name="pair_daily_hours_14">الساعات اليومية (14 يومًا)</string>
+    <string name="pair_charge_cycles">دورات الشحن</string>
+    <string name="pair_per_charge">لكل شحنة</string>
+    <string name="pair_cycles">دورات</string>
+    <string name="pair_charge_watched">مرصود</string>
+    <string name="pair_cycle_number">الدورة %1$d</string>
     <string name="pair_rename_title">إعادة تسمية الزوج</string>
     <string name="pair_rename_label">الاسم</string>
     <string name="pair_retire_title">إحالة هذا الزوج إلى التقاعد</string>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">প্রতি ঘণ্টায়</string>
     <string name="pair_bought">ক্রয় কৰা</string>
     <string name="pair_daily_hours_14">দৈনিক ঘণ্টা (14 দিন)</string>
+    <string name="pair_charge_cycles">চাৰ্জ চক্ৰ</string>
+    <string name="pair_per_charge">প্ৰতি চাৰ্জ</string>
+    <string name="pair_cycles">চক্ৰ</string>
+    <string name="pair_charge_watched">লক্ষ্য কৰা</string>
+    <string name="pair_cycle_number">চক্ৰ %1$d</string>
     <string name="pair_rename_title">যোৰক পুনৰনাম দিন</string>
     <string name="pair_rename_label">নাম</string>
     <string name="pair_retire_title">এই যোৰক অবসৰ দিন</string>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">প্ৰতি চাৰ্জ</string>
     <string name="pair_cycles">চক্ৰ</string>
     <string name="pair_charge_watched">লক্ষ্য কৰা</string>
+    <string name="pair_vs_new">নতুনৰ তুলনাত</string>
     <string name="pair_cycle_number">চক্ৰ %1$d</string>
     <string name="pair_rename_title">যোৰক পুনৰনাম দিন</string>
     <string name="pair_rename_label">নাম</string>

--- a/app/src/main/res/values-b+agq/strings.xml
+++ b/app/src/main/res/values-b+agq/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">à tsàŋ</string>
     <string name="pair_cycles">sìkəl</string>
     <string name="pair_charge_watched">à yìì</string>
+    <string name="pair_vs_new">à zɨ̀ dzɨ̀ŋ</string>
     <string name="pair_cycle_number">sìkəl %1$d</string>
     <string name="pair_rename_title">gó kó îsàm ndap</string>
     <string name="pair_rename_label">îsàm</string>

--- a/app/src/main/res/values-b+agq/strings.xml
+++ b/app/src/main/res/values-b+agq/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">nábè kà</string>
     <string name="pair_bought">à wùm</string>
     <string name="pair_daily_hours_14">nábè à yál (14 yál)</string>
+    <string name="pair_charge_cycles">sìkəl tsə̀ tsàŋ</string>
+    <string name="pair_per_charge">à tsàŋ</string>
+    <string name="pair_cycles">sìkəl</string>
+    <string name="pair_charge_watched">à yìì</string>
+    <string name="pair_cycle_number">sìkəl %1$d</string>
     <string name="pair_rename_title">gó kó îsàm ndap</string>
     <string name="pair_rename_label">îsàm</string>
     <string name="pair_retire_title">gó yi ndap ìyà</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">per carga</string>
     <string name="pair_cycles">ciclos</string>
     <string name="pair_charge_watched">observao</string>
+    <string name="pair_vs_new">frente a nueves</string>
     <string name="pair_cycle_number">ciclu %1$d</string>
     <string name="pair_rename_title">renombrar par</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">per hora</string>
     <string name="pair_bought">compráu</string>
     <string name="pair_daily_hours_14">hores diariu (14 díes)</string>
+    <string name="pair_charge_cycles">ciclos de carga</string>
+    <string name="pair_per_charge">per carga</string>
+    <string name="pair_cycles">ciclos</string>
+    <string name="pair_charge_watched">observao</string>
+    <string name="pair_cycle_number">ciclu %1$d</string>
     <string name="pair_rename_title">renombrar par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">xubildar esta par</string>

--- a/app/src/main/res/values-b+az+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+az+Cyrl/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">саат башына</string>
     <string name="pair_bought">сатын алынды</string>
     <string name="pair_daily_hours_14">ҝүнлүк саатлар (14 ҝүн)</string>
+    <string name="pair_charge_cycles">долдурма дөврләри</string>
+    <string name="pair_per_charge">һәр долдурмаја</string>
+    <string name="pair_cycles">дөврләр</string>
+    <string name="pair_charge_watched">мүшаһидә олунуб</string>
+    <string name="pair_cycle_number">дөвр %1$d</string>
     <string name="pair_rename_title">ҹүтлүјү адландыр</string>
     <string name="pair_rename_label">ад</string>
     <string name="pair_retire_title">бу ҹүтлүјү арадан галдыр</string>

--- a/app/src/main/res/values-b+az+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+az+Cyrl/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">һәр долдурмаја</string>
     <string name="pair_cycles">дөврләр</string>
     <string name="pair_charge_watched">мүшаһидә олунуб</string>
+    <string name="pair_vs_new">јени олдуғу вахтла</string>
     <string name="pair_cycle_number">дөвр %1$d</string>
     <string name="pair_rename_title">ҹүтлүјү адландыр</string>
     <string name="pair_rename_label">ад</string>

--- a/app/src/main/res/values-b+az+Latn/strings.xml
+++ b/app/src/main/res/values-b+az+Latn/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">hər doldurmaya</string>
     <string name="pair_cycles">dövrlər</string>
     <string name="pair_charge_watched">müşahidə olunub</string>
+    <string name="pair_vs_new">yeni olduğu vaxtla</string>
     <string name="pair_cycle_number">dövr %1$d</string>
     <string name="pair_rename_title">cütlüyü adlandır</string>
     <string name="pair_rename_label">ad</string>

--- a/app/src/main/res/values-b+az+Latn/strings.xml
+++ b/app/src/main/res/values-b+az+Latn/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">saat başına</string>
     <string name="pair_bought">satın alındı</string>
     <string name="pair_daily_hours_14">günlük saatlar (14 gün)</string>
+    <string name="pair_charge_cycles">doldurma dövrləri</string>
+    <string name="pair_per_charge">hər doldurmaya</string>
+    <string name="pair_cycles">dövrlər</string>
+    <string name="pair_charge_watched">müşahidə olunub</string>
+    <string name="pair_cycle_number">dövr %1$d</string>
     <string name="pair_rename_title">cütlüyü adlandır</string>
     <string name="pair_rename_label">ad</string>
     <string name="pair_retire_title">bu cütlüyü aradan qaldır</string>

--- a/app/src/main/res/values-b+bas/strings.xml
+++ b/app/src/main/res/values-b+bas/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">mu kwé</string>
     <string name="pair_bought">gɛ́</string>
     <string name="pair_daily_hours_14">kwé/ñen (14 ñen)</string>
+    <string name="pair_charge_cycles">masikèl ma ŋgu</string>
+    <string name="pair_per_charge">inyu ŋgu yada</string>
+    <string name="pair_cycles">masikèl</string>
+    <string name="pair_charge_watched">ba tehe</string>
+    <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">sɔŋ nà kuɓ</string>
     <string name="pair_rename_label">cam</string>
     <string name="pair_retire_title">nyɔ kuɓ</string>

--- a/app/src/main/res/values-b+bas/strings.xml
+++ b/app/src/main/res/values-b+bas/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">inyu ŋgu yada</string>
     <string name="pair_cycles">masikèl</string>
     <string name="pair_charge_watched">ba tehe</string>
+    <string name="pair_vs_new">ni mondo</string>
     <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">sɔŋ nà kuɓ</string>
     <string name="pair_rename_label">cam</string>

--- a/app/src/main/res/values-b+bem/strings.xml
+++ b/app/src/main/res/values-b+bem/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">pakati ya mahola</string>
     <string name="pair_bought">ikombilwe</string>
     <string name="pair_daily_hours_14">amahola pa inshuba (14 inshuba)</string>
+    <string name="pair_charge_cycles">ifipimo fya maka</string>
+    <string name="pair_per_charge">pa maka yamo</string>
+    <string name="pair_cycles">ifipimo</string>
+    <string name="pair_charge_watched">ifyamonwa</string>
+    <string name="pair_cycle_number">icipimo %1$d</string>
     <string name="pair_rename_title">lifumine ilina ilingi ya ifipela</string>
     <string name="pair_rename_label">ilina</string>
     <string name="pair_retire_title">lefuze ifipela fino</string>

--- a/app/src/main/res/values-b+bem/strings.xml
+++ b/app/src/main/res/values-b+bem/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">pa maka yamo</string>
     <string name="pair_cycles">ifipimo</string>
     <string name="pair_charge_watched">ifyamonwa</string>
+    <string name="pair_vs_new">ukulinganya na fipya</string>
     <string name="pair_cycle_number">icipimo %1$d</string>
     <string name="pair_rename_title">lifumine ilina ilingi ya ifipela</string>
     <string name="pair_rename_label">ilina</string>

--- a/app/src/main/res/values-b+bho/strings.xml
+++ b/app/src/main/res/values-b+bho/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">हर घंटा</string>
     <string name="pair_bought">खरीदल</string>
     <string name="pair_daily_hours_14">रोज के घंटा (14 दिन)</string>
+    <string name="pair_charge_cycles">चार्ज चक्र</string>
+    <string name="pair_per_charge">हर चार्ज पर</string>
+    <string name="pair_cycles">चक्र</string>
+    <string name="pair_charge_watched">देखल गइल</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ी के नाम बदल</string>
     <string name="pair_rename_label">नाम</string>
     <string name="pair_retire_title">एही जोड़ी के पुरान कर</string>

--- a/app/src/main/res/values-b+bho/strings.xml
+++ b/app/src/main/res/values-b+bho/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">हर चार्ज पर</string>
     <string name="pair_cycles">चक्र</string>
     <string name="pair_charge_watched">देखल गइल</string>
+    <string name="pair_vs_new">नया के मुकाबले</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ी के नाम बदल</string>
     <string name="pair_rename_label">नाम</string>

--- a/app/src/main/res/values-b+blo/strings.xml
+++ b/app/src/main/res/values-b+blo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">sikili kuɖo</string>
     <string name="pair_cycles">sikili</string>
     <string name="pair_charge_watched">a mɔ</string>
+    <string name="pair_vs_new">kↄ yɔyɔ</string>
     <string name="pair_cycle_number">sikili %1$d</string>
     <string name="pair_rename_title">a bi ta ka ta</string>
     <string name="pair_rename_label">a bi</string>

--- a/app/src/main/res/values-b+blo/strings.xml
+++ b/app/src/main/res/values-b+blo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">a sa wu</string>
     <string name="pair_bought">a bo yi</string>
     <string name="pair_daily_hours_14">a yi sa (14 yi)</string>
+    <string name="pair_charge_cycles">sikili tɛ</string>
+    <string name="pair_per_charge">sikili kuɖo</string>
+    <string name="pair_cycles">sikili</string>
+    <string name="pair_charge_watched">a mɔ</string>
+    <string name="pair_cycle_number">sikili %1$d</string>
     <string name="pair_rename_title">a bi ta ka ta</string>
     <string name="pair_rename_label">a bi</string>
     <string name="pair_retire_title">a yo di a bi yi</string>

--- a/app/src/main/res/values-b+bs+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+bs+Cyrl/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">по пуњењу</string>
     <string name="pair_cycles">циклуси</string>
     <string name="pair_charge_watched">посматрано</string>
+    <string name="pair_vs_new">у односу на нове</string>
     <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>

--- a/app/src/main/res/values-b+bs+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+bs+Cyrl/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">по сату</string>
     <string name="pair_bought">куплене</string>
     <string name="pair_daily_hours_14">дневни сати (14 дана)</string>
+    <string name="pair_charge_cycles">циклуси пуњења</string>
+    <string name="pair_per_charge">по пуњењу</string>
+    <string name="pair_cycles">циклуси</string>
+    <string name="pair_charge_watched">посматрано</string>
+    <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>
     <string name="pair_retire_title">повучи овај пар</string>

--- a/app/src/main/res/values-b+bs+Latn/strings.xml
+++ b/app/src/main/res/values-b+bs+Latn/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">po satu</string>
     <string name="pair_bought">kupljene</string>
     <string name="pair_daily_hours_14">dnevni sati (14 dana)</string>
+    <string name="pair_charge_cycles">ciklusi punjenja</string>
+    <string name="pair_per_charge">po punjenju</string>
+    <string name="pair_cycles">ciklusi</string>
+    <string name="pair_charge_watched">posmatrano</string>
+    <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenovaj paru</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">povuci ovu paru u penziju</string>

--- a/app/src/main/res/values-b+bs+Latn/strings.xml
+++ b/app/src/main/res/values-b+bs+Latn/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">po punjenju</string>
     <string name="pair_cycles">ciklusi</string>
     <string name="pair_charge_watched">posmatrano</string>
+    <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenovaj paru</string>
     <string name="pair_rename_label">ime</string>

--- a/app/src/main/res/values-b+ceb/strings.xml
+++ b/app/src/main/res/values-b+ceb/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">matag charge</string>
     <string name="pair_cycles">mga siklo</string>
     <string name="pair_charge_watched">naobserbahan</string>
+    <string name="pair_vs_new">kumpara sa bag-o</string>
     <string name="pair_cycle_number">siklo %1$d</string>
     <string name="pair_rename_title">baguhin ang pangalan ng pares</string>
     <string name="pair_rename_label">pangalan</string>

--- a/app/src/main/res/values-b+ceb/strings.xml
+++ b/app/src/main/res/values-b+ceb/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">kada oras</string>
     <string name="pair_bought">binili</string>
     <string name="pair_daily_hours_14">pang-araw-araw na oras (14 araw)</string>
+    <string name="pair_charge_cycles">mga siklo sa charge</string>
+    <string name="pair_per_charge">matag charge</string>
+    <string name="pair_cycles">mga siklo</string>
+    <string name="pair_charge_watched">naobserbahan</string>
+    <string name="pair_cycle_number">siklo %1$d</string>
     <string name="pair_rename_title">baguhin ang pangalan ng pares</string>
     <string name="pair_rename_label">pangalan</string>
     <string name="pair_retire_title">iwan ang pares na ito</string>

--- a/app/src/main/res/values-b+cgg/strings.xml
+++ b/app/src/main/res/values-b+cgg/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">aha maani gamwe</string>
     <string name="pair_cycles">emizunguko</string>
     <string name="pair_charge_watched">ekireeberwe</string>
+    <string name="pair_vs_new">kugyerangaho n’ebisya</string>
     <string name="pair_cycle_number">omuzunguko %1$d</string>
     <string name="pair_rename_title">tyoma ikina lya enandi</string>
     <string name="pair_rename_label">ikina</string>

--- a/app/src/main/res/values-b+cgg/strings.xml
+++ b/app/src/main/res/values-b+cgg/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ku saati</string>
     <string name="pair_bought">agakurirwe</string>
     <string name="pair_daily_hours_14">saati ku musi (14 amasigara)</string>
+    <string name="pair_charge_cycles">emizunguko y’amaani</string>
+    <string name="pair_per_charge">aha maani gamwe</string>
+    <string name="pair_cycles">emizunguko</string>
+    <string name="pair_charge_watched">ekireeberwe</string>
+    <string name="pair_cycle_number">omuzunguko %1$d</string>
     <string name="pair_rename_title">tyoma ikina lya enandi</string>
     <string name="pair_rename_label">ikina</string>
     <string name="pair_retire_title">zikira enandi ayo</string>

--- a/app/src/main/res/values-b+chr/strings.xml
+++ b/app/src/main/res/values-b+chr/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ᎨᎮᎵᏍᎬ ᏍᏍᎦ</string>
     <string name="pair_bought">ᏔᎰᏗ ᏂᏂ</string>
     <string name="pair_daily_hours_14">ᎠᎵᏁᏟᏒ ᏒᏂ ᎨᎮᎵᏍᎬ (14 ᎾᎬᎾᎴ)</string>
+    <string name="pair_charge_cycles">ᏗᏓᏅᏬᏗ ᏗᎦᏔᎾ</string>
+    <string name="pair_per_charge">ᏌᏉ ᏗᏓᏅᏬᏗ</string>
+    <string name="pair_cycles">ᏗᎦᏔᎾ</string>
+    <string name="pair_charge_watched">ᎠᎦᏙᎥᏒᎢ</string>
+    <string name="pair_cycle_number">ᎦᏔᎾ %1$d</string>
     <string name="pair_rename_title">ᏂᏗᏪᏦ ᎠᏑᏝ ᎠᎵᏁᏟᏗ</string>
     <string name="pair_rename_label">ᎠᏑᏝ</string>
     <string name="pair_retire_title">ᏂᏗᏪᏦ ᎠᎾᏈᎸᏴᏗ</string>

--- a/app/src/main/res/values-b+chr/strings.xml
+++ b/app/src/main/res/values-b+chr/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ᏌᏉ ᏗᏓᏅᏬᏗ</string>
     <string name="pair_cycles">ᏗᎦᏔᎾ</string>
     <string name="pair_charge_watched">ᎠᎦᏙᎥᏒᎢ</string>
+    <string name="pair_vs_new">ᎢᏤ ᎨᏒᎢ</string>
     <string name="pair_cycle_number">ᎦᏔᎾ %1$d</string>
     <string name="pair_rename_title">ᏂᏗᏪᏦ ᎠᏑᏝ ᎠᎵᏁᏟᏗ</string>
     <string name="pair_rename_label">ᎠᏑᏝ</string>

--- a/app/src/main/res/values-b+csw/strings.xml
+++ b/app/src/main/res/values-b+csw/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ᐯᔭᐠ ᐊᔅᑭᐦᐁᐧᐃᐣ</string>
     <string name="pair_cycles">ᐋᔭᐦᑭᐧᐃᓇ</string>
     <string name="pair_charge_watched">ᑭᑭᓇᐋᐧᐸᐦᑕᒼ</string>
+    <string name="pair_vs_new">ᐅᐢᑭ ᐋᐧᐸᐢᑭᐣ</string>
     <string name="pair_cycle_number">ᐋᔭᐦᑭᐧᐃᐣ %1$d</string>
     <string name="pair_rename_title">ᐊᑕᔨᑲᓱᐤ ᐅᑎᓯᓇᕽ</string>
     <string name="pair_rename_label">ᐊᑕᔭ</string>

--- a/app/src/main/res/values-b+csw/strings.xml
+++ b/app/src/main/res/values-b+csw/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ᐁᑐ ᒪᕽᐅᕽ</string>
     <string name="pair_bought">ᑭ ᐊᑕᔨᒃ</string>
     <string name="pair_daily_hours_14">ᒪᕽᐅᕽᐊᓇ ᐊᔨᓯᔨᓂᐤ (14 ᐅᓴᑉ)</string>
+    <string name="pair_charge_cycles">ᐊᔅᑭᐦᐁᐧᐃᐣ ᐋᔭᐦᑭᐧᐃᓇ</string>
+    <string name="pair_per_charge">ᐯᔭᐠ ᐊᔅᑭᐦᐁᐧᐃᐣ</string>
+    <string name="pair_cycles">ᐋᔭᐦᑭᐧᐃᓇ</string>
+    <string name="pair_charge_watched">ᑭᑭᓇᐋᐧᐸᐦᑕᒼ</string>
+    <string name="pair_cycle_number">ᐋᔭᐦᑭᐧᐃᐣ %1$d</string>
     <string name="pair_rename_title">ᐊᑕᔨᑲᓱᐤ ᐅᑎᓯᓇᕽ</string>
     <string name="pair_rename_label">ᐊᑕᔭ</string>
     <string name="pair_retire_title">ᐘᑲᕀ ᐁᓱ ᐅᑎᓯᓇᕽ</string>

--- a/app/src/main/res/values-b+dje/strings.xml
+++ b/app/src/main/res/values-b+dje/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">gaabu folloŋ ga</string>
     <string name="pair_cycles">windiyaŋ</string>
     <string name="pair_charge_watched">i guna</string>
+    <string name="pair_vs_new">taasi nda tajji</string>
     <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">suubay hima</string>
     <string name="pair_rename_label">suuba</string>

--- a/app/src/main/res/values-b+dje/strings.xml
+++ b/app/src/main/res/values-b+dje/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">agandu foo</string>
     <string name="pair_bought">sanda</string>
     <string name="pair_daily_hours_14">agandu jema (14 jema)</string>
+    <string name="pair_charge_cycles">gaabu windiyaŋ</string>
+    <string name="pair_per_charge">gaabu folloŋ ga</string>
+    <string name="pair_cycles">windiyaŋ</string>
+    <string name="pair_charge_watched">i guna</string>
+    <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">suubay hima</string>
     <string name="pair_rename_label">suuba</string>
     <string name="pair_retire_title">fuley hima kabu</string>

--- a/app/src/main/res/values-b+dsb/strings.xml
+++ b/app/src/main/res/values-b+dsb/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">na nabiśe</string>
     <string name="pair_cycles">cykluse</string>
     <string name="pair_charge_watched">wobglědowane</string>
+    <string name="pair_vs_new">napśeśiwo nowym</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">pśemjeniś paru</string>
     <string name="pair_rename_label">mě</string>

--- a/app/src/main/res/values-b+dsb/strings.xml
+++ b/app/src/main/res/values-b+dsb/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">za hodinu</string>
     <string name="pair_bought">kupjeny</string>
     <string name="pair_daily_hours_14">hodinow na źeń (14 dnjow)</string>
+    <string name="pair_charge_cycles">nabijańske cykluse</string>
+    <string name="pair_per_charge">na nabiśe</string>
+    <string name="pair_cycles">cykluse</string>
+    <string name="pair_charge_watched">wobglědowane</string>
+    <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">pśemjeniś paru</string>
     <string name="pair_rename_label">mě</string>
     <string name="pair_retire_title">toś tu paru pensioniriś</string>

--- a/app/src/main/res/values-b+dua/strings.xml
+++ b/app/src/main/res/values-b+dua/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">o ngiña wɔ́</string>
     <string name="pair_cycles">masikèl</string>
     <string name="pair_charge_watched">ba enè</string>
+    <string name="pair_vs_new">na peki</string>
     <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">sombela likúmu wa ndúmu</string>
     <string name="pair_rename_label">likúmu</string>

--- a/app/src/main/res/values-b+dua/strings.xml
+++ b/app/src/main/res/values-b+dua/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">mbe mota wa mabe</string>
     <string name="pair_bought">osombé</string>
     <string name="pair_daily_hours_14">mabe wa mílu (mílu 14)</string>
+    <string name="pair_charge_cycles">masikèl ma ngiña</string>
+    <string name="pair_per_charge">o ngiña wɔ́</string>
+    <string name="pair_cycles">masikèl</string>
+    <string name="pair_charge_watched">ba enè</string>
+    <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">sombela likúmu wa ndúmu</string>
     <string name="pair_rename_label">likúmu</string>
     <string name="pair_retire_title">kona ye ndúmu mota</string>

--- a/app/src/main/res/values-b+dyo/strings.xml
+++ b/app/src/main/res/values-b+dyo/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">kaarj yaakon</string>
     <string name="pair_cycles">sikili</string>
     <string name="pair_charge_watched">bujuk</string>
+    <string name="pair_vs_new">ni bukoolen</string>
     <string name="pair_cycle_number">sikili %1$d</string>
     <string name="pair_rename_title">yontoo caani yindoo</string>
     <string name="pair_rename_label">caani</string>

--- a/app/src/main/res/values-b+dyo/strings.xml
+++ b/app/src/main/res/values-b+dyo/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">waray yontoo</string>
     <string name="pair_bought">kañante</string>
     <string name="pair_daily_hours_14">waray ba dima (14 bu taasu)</string>
+    <string name="pair_charge_cycles">sikili su kaarj</string>
+    <string name="pair_per_charge">kaarj yaakon</string>
+    <string name="pair_cycles">sikili</string>
+    <string name="pair_charge_watched">bujuk</string>
+    <string name="pair_cycle_number">sikili %1$d</string>
     <string name="pair_rename_title">yontoo caani yindoo</string>
     <string name="pair_rename_label">caani</string>
     <string name="pair_retire_title">yontoo yi cif</string>

--- a/app/src/main/res/values-b+ebu/strings.xml
+++ b/app/src/main/res/values-b+ebu/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">kwa inengi rimwe</string>
     <string name="pair_cycles">mĩthiũrũko</string>
     <string name="pair_charge_watched">gũthuthuria</string>
+    <string name="pair_vs_new">kũringithania na njeru</string>
     <string name="pair_cycle_number">mũthiũrũko %1$d</string>
     <string name="pair_rename_title">ĩmenyithia rĩĩta ria mbere</string>
     <string name="pair_rename_label">rĩĩta</string>

--- a/app/src/main/res/values-b+ebu/strings.xml
+++ b/app/src/main/res/values-b+ebu/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">kwa mahinda</string>
     <string name="pair_bought">yoothĩtwo</string>
     <string name="pair_daily_hours_14">mahinda ma rua (mahinda 14)</string>
+    <string name="pair_charge_cycles">mĩthiũrũko ya inengi</string>
+    <string name="pair_per_charge">kwa inengi rimwe</string>
+    <string name="pair_cycles">mĩthiũrũko</string>
+    <string name="pair_charge_watched">gũthuthuria</string>
+    <string name="pair_cycle_number">mũthiũrũko %1$d</string>
     <string name="pair_rename_title">ĩmenyithia rĩĩta ria mbere</string>
     <string name="pair_rename_label">rĩĩta</string>
     <string name="pair_retire_title">ruta mbere ĩyo</string>

--- a/app/src/main/res/values-b+ewo/strings.xml
+++ b/app/src/main/res/values-b+ewo/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ti kuε bot</string>
     <string name="pair_bought">bekum</string>
     <string name="pair_daily_hours_14">kuε ye zepot (zitom ye 14)</string>
+    <string name="pair_charge_cycles">misikèl mi ngul</string>
+    <string name="pair_per_charge">ngul fɔ́</string>
+    <string name="pair_cycles">misikèl</string>
+    <string name="pair_charge_watched">bé yén</string>
+    <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">basa eve bikule bot</string>
     <string name="pair_rename_label">zina</string>
     <string name="pair_retire_title">azinga bikule bot ane</string>

--- a/app/src/main/res/values-b+ewo/strings.xml
+++ b/app/src/main/res/values-b+ewo/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ngul fɔ́</string>
     <string name="pair_cycles">misikèl</string>
     <string name="pair_charge_watched">bé yén</string>
+    <string name="pair_vs_new">ai mfefé</string>
     <string name="pair_cycle_number">sikèl %1$d</string>
     <string name="pair_rename_title">basa eve bikule bot</string>
     <string name="pair_rename_label">zina</string>

--- a/app/src/main/res/values-b+ff+Adlm/strings.xml
+++ b/app/src/main/res/values-b+ff+Adlm/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">𞤺𞤮 𞤳𞤢𞤪𞤶𞤢</string>
     <string name="pair_cycles">𞤧𞤭𞤳𞤵𞤤𞤭</string>
     <string name="pair_charge_watched">𞤴𞤭𞥅𞤴𞤢𞥄𞤲𞤺𞤮</string>
+    <string name="pair_vs_new">𞤦𞤫 𞤳𞤫𞤧𞤵𞤥</string>
     <string name="pair_cycle_number">𞤧𞤭𞤳𞤵𞤤 %1$d</string>
     <string name="pair_rename_title">𞤶𞤮𞥅𞤯𞤭𞤲 𞤶𞤫𞥅𞤩𞤫 𞤥𞤢𞥄</string>
     <string name="pair_rename_label">𞤥𞤢𞤩𞥆𞤫</string>

--- a/app/src/main/res/values-b+ff+Adlm/strings.xml
+++ b/app/src/main/res/values-b+ff+Adlm/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">𞤧𞤢 𞤧𞤢𞥄𞤶𞤭</string>
     <string name="pair_bought">𞤺𞤢𞤪𞤢𞤲𞤢𞥄</string>
     <string name="pair_daily_hours_14">𞤧𞤢𞥄𞤶𞤭 𞤩𞤢𞤤𞤩𞤢𞤷𞥆𞤫𞤪𞤫 (14 𞤩𞤢𞤤𞤩𞤢𞤷𞥆𞤫)</string>
+    <string name="pair_charge_cycles">𞤧𞤭𞤳𞤵𞤤𞤭 𞤳𞤢𞤪𞤶𞤢</string>
+    <string name="pair_per_charge">𞤺𞤮 𞤳𞤢𞤪𞤶𞤢</string>
+    <string name="pair_cycles">𞤧𞤭𞤳𞤵𞤤𞤭</string>
+    <string name="pair_charge_watched">𞤴𞤭𞥅𞤴𞤢𞥄𞤲𞤺𞤮</string>
+    <string name="pair_cycle_number">𞤧𞤭𞤳𞤵𞤤 %1$d</string>
     <string name="pair_rename_title">𞤶𞤮𞥅𞤯𞤭𞤲 𞤶𞤫𞥅𞤩𞤫 𞤥𞤢𞥄</string>
     <string name="pair_rename_label">𞤥𞤢𞤩𞥆𞤫</string>
     <string name="pair_retire_title">𞤣𞤫𞤬𞤼𞤵𞤺𞤵 𞤶𞤫𞥅𞤩𞤫 𞤥𞤢𞥄</string>

--- a/app/src/main/res/values-b+ff+Latn/strings.xml
+++ b/app/src/main/res/values-b+ff+Latn/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">go karja</string>
     <string name="pair_cycles">sikuli</string>
     <string name="pair_charge_watched">yiiyaango</string>
+    <string name="pair_vs_new">e nder kesum</string>
     <string name="pair_cycle_number">sikul %1$d</string>
     <string name="pair_rename_title">mare peere maa</string>
     <string name="pair_rename_label">ɗowol</string>

--- a/app/src/main/res/values-b+ff+Latn/strings.xml
+++ b/app/src/main/res/values-b+ff+Latn/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">to waktuu duuɗe</string>
     <string name="pair_bought">kaye</string>
     <string name="pair_daily_hours_14">waktuuji baŋko (joomuuji 14)</string>
+    <string name="pair_charge_cycles">sikuli karja</string>
+    <string name="pair_per_charge">go karja</string>
+    <string name="pair_cycles">sikuli</string>
+    <string name="pair_charge_watched">yiiyaango</string>
+    <string name="pair_cycle_number">sikul %1$d</string>
     <string name="pair_rename_title">mare peere maa</string>
     <string name="pair_rename_label">ɗowol</string>
     <string name="pair_retire_title">binde peere ngii</string>

--- a/app/src/main/res/values-b+fil/strings.xml
+++ b/app/src/main/res/values-b+fil/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">bawat oras</string>
     <string name="pair_bought">binili</string>
     <string name="pair_daily_hours_14">oras bawat araw (14 araw)</string>
+    <string name="pair_charge_cycles">mga cycle ng charge</string>
+    <string name="pair_per_charge">kada charge</string>
+    <string name="pair_cycles">mga cycle</string>
+    <string name="pair_charge_watched">naobserbahan</string>
+    <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">baguhin ang pangalan ng pares</string>
     <string name="pair_rename_label">pangalan</string>
     <string name="pair_retire_title">iretiro ang pares na ito</string>

--- a/app/src/main/res/values-b+fil/strings.xml
+++ b/app/src/main/res/values-b+fil/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">kada charge</string>
     <string name="pair_cycles">mga cycle</string>
     <string name="pair_charge_watched">naobserbahan</string>
+    <string name="pair_vs_new">kumpara noong bago</string>
     <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">baguhin ang pangalan ng pares</string>
     <string name="pair_rename_label">pangalan</string>

--- a/app/src/main/res/values-b+fur/strings.xml
+++ b/app/src/main/res/values-b+fur/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">par ore</string>
     <string name="pair_bought">compratis</string>
     <string name="pair_daily_hours_14">oris al dì (14 dis)</string>
+    <string name="pair_charge_cycles">ciclis di ricjarie</string>
+    <string name="pair_per_charge">par ricjarie</string>
+    <string name="pair_cycles">ciclis</string>
+    <string name="pair_charge_watched">osservât</string>
+    <string name="pair_cycle_number">cicli %1$d</string>
     <string name="pair_rename_title">ribate non a cheste cuglia</string>
     <string name="pair_rename_label">non</string>
     <string name="pair_retire_title">pensionâ cheste cuglia</string>

--- a/app/src/main/res/values-b+fur/strings.xml
+++ b/app/src/main/res/values-b+fur/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">par ricjarie</string>
     <string name="pair_cycles">ciclis</string>
     <string name="pair_charge_watched">osservât</string>
+    <string name="pair_vs_new">rispiet a gnûfs</string>
     <string name="pair_cycle_number">cicli %1$d</string>
     <string name="pair_rename_title">ribate non a cheste cuglia</string>
     <string name="pair_rename_label">non</string>

--- a/app/src/main/res/values-b+gsw/strings.xml
+++ b/app/src/main/res/values-b+gsw/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pro stunde</string>
     <string name="pair_bought">gekauft</string>
     <string name="pair_daily_hours_14">tägliche stunden (14 tage)</string>
+    <string name="pair_charge_cycles">ladezyklä</string>
+    <string name="pair_per_charge">pro ladig</string>
+    <string name="pair_cycles">zyklä</string>
+    <string name="pair_charge_watched">beobachtet</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">dieses paar in rente</string>

--- a/app/src/main/res/values-b+gsw/strings.xml
+++ b/app/src/main/res/values-b+gsw/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro ladig</string>
     <string name="pair_cycles">zyklä</string>
     <string name="pair_charge_watched">beobachtet</string>
+    <string name="pair_vs_new">gägenüber neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">name</string>

--- a/app/src/main/res/values-b+guz/strings.xml
+++ b/app/src/main/res/values-b+guz/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ase amanga amo</string>
     <string name="pair_cycles">chibetero</string>
     <string name="pair_charge_watched">chiaroretwe</string>
+    <string name="pair_vs_new">kobwatania na ebiyia</string>
     <string name="pair_cycle_number">ekebetero %1$d</string>
     <string name="pair_rename_title">tigira yite omurango</string>
     <string name="pair_rename_label">yite</string>

--- a/app/src/main/res/values-b+guz/strings.xml
+++ b/app/src/main/res/values-b+guz/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">koum cha masaa</string>
     <string name="pair_bought">igomire</string>
     <string name="pair_daily_hours_14">amasaa go omwori (amin ayo 14)</string>
+    <string name="pair_charge_cycles">chibetero chia amanga</string>
+    <string name="pair_per_charge">ase amanga amo</string>
+    <string name="pair_cycles">chibetero</string>
+    <string name="pair_charge_watched">chiaroretwe</string>
+    <string name="pair_cycle_number">ekebetero %1$d</string>
     <string name="pair_rename_title">tigira yite omurango</string>
     <string name="pair_rename_label">yite</string>
     <string name="pair_retire_title">igoiguare omurango oyu</string>

--- a/app/src/main/res/values-b+haw/strings.xml
+++ b/app/src/main/res/values-b+haw/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ma kēlā hola</string>
     <string name="pair_bought">hōʻili ʻia</string>
     <string name="pair_daily_hours_14">nā hola o kēlā me kēia lā (14 lā)</string>
+    <string name="pair_charge_cycles">nā pōʻai hoʻopiha</string>
+    <string name="pair_per_charge">i kēlā hoʻopiha</string>
+    <string name="pair_cycles">nā pōʻai</string>
+    <string name="pair_charge_watched">nānā ʻia</string>
+    <string name="pair_cycle_number">pōʻai %1$d</string>
     <string name="pair_rename_title">hoʻololi i ka inoa o ka hoʻolohe leo</string>
     <string name="pair_rename_label">inoa</string>
     <string name="pair_retire_title">hoʻopau i kēia hoʻolohe leo</string>

--- a/app/src/main/res/values-b+haw/strings.xml
+++ b/app/src/main/res/values-b+haw/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">i kēlā hoʻopiha</string>
     <string name="pair_cycles">nā pōʻai</string>
     <string name="pair_charge_watched">nānā ʻia</string>
+    <string name="pair_vs_new">i ka wā hou</string>
     <string name="pair_cycle_number">pōʻai %1$d</string>
     <string name="pair_rename_title">hoʻololi i ka inoa o ka hoʻolohe leo</string>
     <string name="pair_rename_label">inoa</string>

--- a/app/src/main/res/values-b+hi+Latn/strings.xml
+++ b/app/src/main/res/values-b+hi+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">prati chārj</string>
     <string name="pair_cycles">chakra</string>
     <string name="pair_charge_watched">dekhā gayā</string>
+    <string name="pair_vs_new">naye kī tulnā mẽ</string>
     <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">zyda kā nām badlein</string>
     <string name="pair_rename_label">nām</string>

--- a/app/src/main/res/values-b+hi+Latn/strings.xml
+++ b/app/src/main/res/values-b+hi+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ek ghnte mein</string>
     <string name="pair_bought">kharīdā</string>
     <string name="pair_daily_hours_14">roz ke ghnten (14 din)</string>
+    <string name="pair_charge_cycles">chārj chakra</string>
+    <string name="pair_per_charge">prati chārj</string>
+    <string name="pair_cycles">chakra</string>
+    <string name="pair_charge_watched">dekhā gayā</string>
+    <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">zyda kā nām badlein</string>
     <string name="pair_rename_label">nām</string>
     <string name="pair_retire_title">is zyda ko sannyas den</string>

--- a/app/src/main/res/values-b+hsb/strings.xml
+++ b/app/src/main/res/values-b+hsb/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na nabiće</string>
     <string name="pair_cycles">cykle</string>
     <string name="pair_charge_watched">wobkedźbowane</string>
+    <string name="pair_vs_new">napřećo nowym</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">paru přemjenować</string>
     <string name="pair_rename_label">mjeno</string>

--- a/app/src/main/res/values-b+hsb/strings.xml
+++ b/app/src/main/res/values-b+hsb/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">na hodźinu</string>
     <string name="pair_bought">nakupjena</string>
     <string name="pair_daily_hours_14">každodennje hodźiny (14 dnjow)</string>
+    <string name="pair_charge_cycles">nabiwanske cykle</string>
+    <string name="pair_per_charge">na nabiće</string>
+    <string name="pair_cycles">cykle</string>
+    <string name="pair_charge_watched">wobkedźbowane</string>
+    <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">paru přemjenować</string>
     <string name="pair_rename_label">mjeno</string>
     <string name="pair_retire_title">tutu paru zažywić</string>

--- a/app/src/main/res/values-b+jgo/strings.xml
+++ b/app/src/main/res/values-b+jgo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">nə́ ŋgáŋ</string>
     <string name="pair_bought">ndzú</string>
     <string name="pair_daily_hours_14">ŋgáŋ yɛ́ ŋwɔ́ŋ (ŋwɔ́ŋ 14)</string>
+    <string name="pair_charge_cycles">sikǝl mǝ ntsɛ́</string>
+    <string name="pair_per_charge">ntsɛ́ pɔ́</string>
+    <string name="pair_cycles">sikǝl</string>
+    <string name="pair_charge_watched">pʉ́ə́ yə</string>
+    <string name="pair_cycle_number">sikǝl %1$d</string>
     <string name="pair_rename_title">tsə́ ndzɨ́ŋ yɛ́ ntsɔ́ʼ</string>
     <string name="pair_rename_label">ndzɨ́ŋ</string>
     <string name="pair_retire_title">tsɔ́ŋ ntsɔ́ʼ zə́</string>

--- a/app/src/main/res/values-b+jgo/strings.xml
+++ b/app/src/main/res/values-b+jgo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ntsɛ́ pɔ́</string>
     <string name="pair_cycles">sikǝl</string>
     <string name="pair_charge_watched">pʉ́ə́ yə</string>
+    <string name="pair_vs_new">nɛ́ pɔ́ fyɛ</string>
     <string name="pair_cycle_number">sikǝl %1$d</string>
     <string name="pair_rename_title">tsə́ ndzɨ́ŋ yɛ́ ntsɔ́ʼ</string>
     <string name="pair_rename_label">ndzɨ́ŋ</string>

--- a/app/src/main/res/values-b+kab/strings.xml
+++ b/app/src/main/res/values-b+kab/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kul tigira</string>
     <string name="pair_bought">ẓra</string>
     <string name="pair_daily_hours_14">tiɣratin i yal ass (14 n wussan)</string>
+    <string name="pair_charge_cycles">tiwinas n uccetki</string>
+    <string name="pair_per_charge">i yal accetki</string>
+    <string name="pair_cycles">tiwinas</string>
+    <string name="pair_charge_watched">yettwaɛassen</string>
+    <string name="pair_cycle_number">tawinest %1$d</string>
     <string name="pair_rename_title">bddel isem talli</string>
     <string name="pair_rename_label">isem</string>
     <string name="pair_retire_title">ḥbes talli-a</string>

--- a/app/src/main/res/values-b+kab/strings.xml
+++ b/app/src/main/res/values-b+kab/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">i yal accetki</string>
     <string name="pair_cycles">tiwinas</string>
     <string name="pair_charge_watched">yettwaɛassen</string>
+    <string name="pair_vs_new">ɣef wamek llan d imaynuten</string>
     <string name="pair_cycle_number">tawinest %1$d</string>
     <string name="pair_rename_title">bddel isem talli</string>
     <string name="pair_rename_label">isem</string>

--- a/app/src/main/res/values-b+kam/strings.xml
+++ b/app/src/main/res/values-b+kam/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa misaa</string>
     <string name="pair_bought">kuthenganiwe</string>
     <string name="pair_daily_hours_14">misaani ya siku (siku 14)</string>
+    <string name="pair_charge_cycles">mithyũlũko ya vinya</string>
+    <string name="pair_per_charge">kwa vinya wimwe</string>
+    <string name="pair_cycles">mithyũlũko</string>
+    <string name="pair_charge_watched">kwoneka</string>
+    <string name="pair_cycle_number">mũthyũlũko %1$d</string>
     <string name="pair_rename_title">mayua linyo lya ikilongi</string>
     <string name="pair_rename_label">linyo</string>
     <string name="pair_retire_title">thiimu ikilongi iino</string>

--- a/app/src/main/res/values-b+kam/strings.xml
+++ b/app/src/main/res/values-b+kam/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa vinya wimwe</string>
     <string name="pair_cycles">mithyũlũko</string>
     <string name="pair_charge_watched">kwoneka</string>
+    <string name="pair_vs_new">kwa kwelekany’a na mweu</string>
     <string name="pair_cycle_number">mũthyũlũko %1$d</string>
     <string name="pair_rename_title">mayua linyo lya ikilongi</string>
     <string name="pair_rename_label">linyo</string>

--- a/app/src/main/res/values-b+kea/strings.xml
+++ b/app/src/main/res/values-b+kea/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pur karga</string>
     <string name="pair_cycles">siklus</string>
     <string name="pair_charge_watched">observadu</string>
+    <string name="pair_vs_new">kompará ku nobu</string>
     <string name="pair_cycle_number">siklu %1$d</string>
     <string name="pair_rename_title">muda nomi par</string>
     <string name="pair_rename_label">nomi</string>

--- a/app/src/main/res/values-b+kea/strings.xml
+++ b/app/src/main/res/values-b+kea/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pur ura</string>
     <string name="pair_bought">kumprádu</string>
     <string name="pair_daily_hours_14">uras dia-a-dia (14 dias)</string>
+    <string name="pair_charge_cycles">siklus di karga</string>
+    <string name="pair_per_charge">pur karga</string>
+    <string name="pair_cycles">siklus</string>
+    <string name="pair_charge_watched">observadu</string>
+    <string name="pair_cycle_number">siklu %1$d</string>
     <string name="pair_rename_title">muda nomi par</string>
     <string name="pair_rename_label">nomi</string>
     <string name="pair_retire_title">aposentá esta par</string>

--- a/app/src/main/res/values-b+kgp/strings.xml
+++ b/app/src/main/res/values-b+kgp/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kõ upe</string>
     <string name="pair_bought">kuprádu</string>
     <string name="pair_daily_hours_14">upe dia (14 dia)</string>
+    <string name="pair_charge_cycles">kanhkã kar mág</string>
+    <string name="pair_per_charge">kanhkã pir</string>
+    <string name="pair_cycles">kar mág</string>
+    <string name="pair_charge_watched">vẽjẽn</string>
+    <string name="pair_cycle_number">kar %1$d</string>
     <string name="pair_rename_title">trok jag kimẽ</string>
     <string name="pair_rename_label">jag</string>
     <string name="pair_retire_title">ku kimẽ iã</string>

--- a/app/src/main/res/values-b+kgp/strings.xml
+++ b/app/src/main/res/values-b+kgp/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kanhkã pir</string>
     <string name="pair_cycles">kar mág</string>
     <string name="pair_charge_watched">vẽjẽn</string>
+    <string name="pair_vs_new">tỹ há mág</string>
     <string name="pair_cycle_number">kar %1$d</string>
     <string name="pair_rename_title">trok jag kimẽ</string>
     <string name="pair_rename_label">jag</string>

--- a/app/src/main/res/values-b+khq/strings.xml
+++ b/app/src/main/res/values-b+khq/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">sanda foo borey</string>
     <string name="pair_bought">kaynte</string>
     <string name="pair_daily_hours_14">zaani sanda (14 zaani)</string>
+    <string name="pair_charge_cycles">gaabu windiyaŋ</string>
+    <string name="pair_per_charge">gaabu foo ga</string>
+    <string name="pair_cycles">windiyaŋ</string>
+    <string name="pair_charge_watched">i guna</string>
+    <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">ceeci tonton taaga</string>
     <string name="pair_rename_label">tonton</string>
     <string name="pair_retire_title">ceeci ga fusu</string>

--- a/app/src/main/res/values-b+khq/strings.xml
+++ b/app/src/main/res/values-b+khq/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">gaabu foo ga</string>
     <string name="pair_cycles">windiyaŋ</string>
     <string name="pair_charge_watched">i guna</string>
+    <string name="pair_vs_new">taasi nda tajji</string>
     <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">ceeci tonton taaga</string>
     <string name="pair_rename_label">tonton</string>

--- a/app/src/main/res/values-b+kkj/strings.xml
+++ b/app/src/main/res/values-b+kkj/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">sàŋ fə</string>
     <string name="pair_bought">bìː</string>
     <string name="pair_daily_hours_14">sɛn ŋɡə (14 sɛn)</string>
+    <string name="pair_charge_cycles">sikɛl mɛ ngbala</string>
+    <string name="pair_per_charge">ngbala wu</string>
+    <string name="pair_cycles">sikɛl</string>
+    <string name="pair_charge_watched">bo jɛ</string>
+    <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">makɔ́ŋ ŋtɔ́n mbɔ</string>
     <string name="pair_rename_label">ŋtɔ́n</string>
     <string name="pair_retire_title">makɔ́ŋ tuŋ́</string>

--- a/app/src/main/res/values-b+kkj/strings.xml
+++ b/app/src/main/res/values-b+kkj/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ngbala wu</string>
     <string name="pair_cycles">sikɛl</string>
     <string name="pair_charge_watched">bo jɛ</string>
+    <string name="pair_vs_new">nɛ mbimbi</string>
     <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">makɔ́ŋ ŋtɔ́n mbɔ</string>
     <string name="pair_rename_label">ŋtɔ́n</string>

--- a/app/src/main/res/values-b+kln/strings.xml
+++ b/app/src/main/res/values-b+kln/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa kimnotet akenge</string>
     <string name="pair_cycles">kolutik</string>
     <string name="pair_charge_watched">kigeere</string>
+    <string name="pair_vs_new">kotugul ak lelach</string>
     <string name="pair_cycle_number">koluto %1$d</string>
     <string name="pair_rename_title">korengo emwusis</string>
     <string name="pair_rename_label">kiit</string>

--- a/app/src/main/res/values-b+kln/strings.xml
+++ b/app/src/main/res/values-b+kln/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa saina</string>
     <string name="pair_bought">kitiit ye</string>
     <string name="pair_daily_hours_14">saina kotagit (14 kotagit)</string>
+    <string name="pair_charge_cycles">kolutik che kimnotin</string>
+    <string name="pair_per_charge">kwa kimnotet akenge</string>
+    <string name="pair_cycles">kolutik</string>
+    <string name="pair_charge_watched">kigeere</string>
+    <string name="pair_cycle_number">koluto %1$d</string>
     <string name="pair_rename_title">korengo emwusis</string>
     <string name="pair_rename_label">kiit</string>
     <string name="pair_retire_title">kosimiyek emwusis</string>

--- a/app/src/main/res/values-b+kok+Deva/strings.xml
+++ b/app/src/main/res/values-b+kok+Deva/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रति तास</string>
     <string name="pair_bought">खरेदी केले</string>
     <string name="pair_daily_hours_14">दैनिक तास (14 दिवस)</string>
+    <string name="pair_charge_cycles">चार्ज चक्रां</string>
+    <string name="pair_per_charge">दर चार्जाक</string>
+    <string name="pair_cycles">चक्रां</string>
+    <string name="pair_charge_watched">पळयलें</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीला पुनः नाव द्या</string>
     <string name="pair_rename_label">नाव</string>
     <string name="pair_retire_title">या जोडीला निवृत्त करा</string>

--- a/app/src/main/res/values-b+kok+Deva/strings.xml
+++ b/app/src/main/res/values-b+kok+Deva/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">दर चार्जाक</string>
     <string name="pair_cycles">चक्रां</string>
     <string name="pair_charge_watched">पळयलें</string>
+    <string name="pair_vs_new">नव्या वेळार</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीला पुनः नाव द्या</string>
     <string name="pair_rename_label">नाव</string>

--- a/app/src/main/res/values-b+kok+Latn/strings.xml
+++ b/app/src/main/res/values-b+kok+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">prati taas</string>
     <string name="pair_bought">kharedi kem</string>
     <string name="pair_daily_hours_14">dainik taas (14 divs)</string>
+    <string name="pair_charge_cycles">charj chakram</string>
+    <string name="pair_per_charge">dar charjak</string>
+    <string name="pair_cycles">chakram</string>
+    <string name="pair_charge_watched">pollem</string>
+    <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">jodihe punn nav de</string>
     <string name="pair_rename_label">nav</string>
     <string name="pair_retire_title">hya jodihe nivrut kra</string>

--- a/app/src/main/res/values-b+kok+Latn/strings.xml
+++ b/app/src/main/res/values-b+kok+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">dar charjak</string>
     <string name="pair_cycles">chakram</string>
     <string name="pair_charge_watched">pollem</string>
+    <string name="pair_vs_new">novea vellar</string>
     <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">jodihe punn nav de</string>
     <string name="pair_rename_label">nav</string>

--- a/app/src/main/res/values-b+ksf/strings.xml
+++ b/app/src/main/res/values-b+ksf/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">bo otu</string>
     <string name="pair_bought">i-nu</string>
     <string name="pair_daily_hours_14">otu kilo miezi (miezi 14)</string>
+    <string name="pair_charge_cycles">sikɛl yé ndáá</string>
+    <string name="pair_per_charge">ndáá yɔ́mɔ́</string>
+    <string name="pair_cycles">sikɛl</string>
+    <string name="pair_charge_watched">bá bɛ́n</string>
+    <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">su nam ba bu-yak</string>
     <string name="pair_rename_label">nam</string>
     <string name="pair_retire_title">puga bu-yak yi</string>

--- a/app/src/main/res/values-b+ksf/strings.xml
+++ b/app/src/main/res/values-b+ksf/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ndáá yɔ́mɔ́</string>
     <string name="pair_cycles">sikɛl</string>
     <string name="pair_charge_watched">bá bɛ́n</string>
+    <string name="pair_vs_new">ni ndúmbú</string>
     <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">su nam ba bu-yak</string>
     <string name="pair_rename_label">nam</string>

--- a/app/src/main/res/values-b+ksh/strings.xml
+++ b/app/src/main/res/values-b+ksh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro laadung</string>
     <string name="pair_cycles">zykle</string>
     <string name="pair_charge_watched">beobaachtet</string>
+    <string name="pair_vs_new">jäjenüver neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ömbenenne</string>
     <string name="pair_rename_label">name</string>

--- a/app/src/main/res/values-b+ksh/strings.xml
+++ b/app/src/main/res/values-b+ksh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">för stunde</string>
     <string name="pair_bought">jekäft</string>
     <string name="pair_daily_hours_14">täjlich stunde (14 täche)</string>
+    <string name="pair_charge_cycles">laadezykle</string>
+    <string name="pair_per_charge">pro laadung</string>
+    <string name="pair_cycles">zykle</string>
+    <string name="pair_charge_watched">beobaachtet</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ömbenenne</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">häm paar en rente</string>

--- a/app/src/main/res/values-b+ku+Latn/strings.xml
+++ b/app/src/main/res/values-b+ku+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per saet</string>
     <string name="pair_bought">kirinê</string>
     <string name="pair_daily_hours_14">saetên rojane (14 rojan)</string>
+    <string name="pair_charge_cycles">çerxên şarjê</string>
+    <string name="pair_per_charge">her şarjek</string>
+    <string name="pair_cycles">çerx</string>
+    <string name="pair_charge_watched">hate temaşekirin</string>
+    <string name="pair_cycle_number">çerx %1$d</string>
     <string name="pair_rename_title">coteka navnav bike</string>
     <string name="pair_rename_label">nav</string>
     <string name="pair_retire_title">vî cotekî zaye bike</string>

--- a/app/src/main/res/values-b+ku+Latn/strings.xml
+++ b/app/src/main/res/values-b+ku+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">her şarjek</string>
     <string name="pair_cycles">çerx</string>
     <string name="pair_charge_watched">hate temaşekirin</string>
+    <string name="pair_vs_new">li gorî nû</string>
     <string name="pair_cycle_number">çerx %1$d</string>
     <string name="pair_rename_title">coteka navnav bike</string>
     <string name="pair_rename_label">nav</string>

--- a/app/src/main/res/values-b+kxv+Deva/strings.xml
+++ b/app/src/main/res/values-b+kxv+Deva/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्राति घान्ता</string>
     <string name="pair_bought">किना आते</string>
     <string name="pair_daily_hours_14">प्राति दिना घान्ता (14 दिना)</string>
+    <string name="pair_charge_cycles">चार्ज चक्र</string>
+    <string name="pair_per_charge">एक चार्ज मुदे</string>
+    <string name="pair_cycles">चक्र</string>
+    <string name="pair_charge_watched">देखते</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडि-ना नौ बादाला किडु</string>
     <string name="pair_rename_label">नौ</string>
     <string name="pair_retire_title">ई जोडि छेडा किडु</string>

--- a/app/src/main/res/values-b+kxv+Deva/strings.xml
+++ b/app/src/main/res/values-b+kxv+Deva/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">एक चार्ज मुदे</string>
     <string name="pair_cycles">चक्र</string>
     <string name="pair_charge_watched">देखते</string>
+    <string name="pair_vs_new">नवा बेल्ते</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडि-ना नौ बादाला किडु</string>
     <string name="pair_rename_label">नौ</string>

--- a/app/src/main/res/values-b+kxv+Latn/strings.xml
+++ b/app/src/main/res/values-b+kxv+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">prati ghanta</string>
     <string name="pair_bought">kina aate</string>
     <string name="pair_daily_hours_14">prati dina ghanta (14 dina)</string>
+    <string name="pair_charge_cycles">charj chakra</string>
+    <string name="pair_per_charge">ek charj mude</string>
+    <string name="pair_cycles">chakra</string>
+    <string name="pair_charge_watched">dekhte</string>
+    <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">joḍi-na nau badala kiḍu</string>
     <string name="pair_rename_label">nau</string>
     <string name="pair_retire_title">ii joḍi cheḍa kiḍu</string>

--- a/app/src/main/res/values-b+kxv+Latn/strings.xml
+++ b/app/src/main/res/values-b+kxv+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ek charj mude</string>
     <string name="pair_cycles">chakra</string>
     <string name="pair_charge_watched">dekhte</string>
+    <string name="pair_vs_new">nawa belte</string>
     <string name="pair_cycle_number">chakra %1$d</string>
     <string name="pair_rename_title">joḍi-na nau badala kiḍu</string>
     <string name="pair_rename_label">nau</string>

--- a/app/src/main/res/values-b+kxv+Orya/strings.xml
+++ b/app/src/main/res/values-b+kxv+Orya/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ପ୍ରାତି ଘାନ୍ତା</string>
     <string name="pair_bought">କିନା ଆତେ</string>
     <string name="pair_daily_hours_14">ପ୍ରାତି ଦିନା ଘାନ୍ତା (14 ଦିନା)</string>
+    <string name="pair_charge_cycles">ଚାର୍ଜ ଚକ୍ର</string>
+    <string name="pair_per_charge">ଏକ ଚାର୍ଜ ମୁଦେ</string>
+    <string name="pair_cycles">ଚକ୍ର</string>
+    <string name="pair_charge_watched">ଦେଖ୍‌ତେ</string>
+    <string name="pair_cycle_number">ଚକ୍ର %1$d</string>
     <string name="pair_rename_title">ଜୋଡ଼ି-ନା ନୌ ବାଦାଲା କିଡ଼ୁ</string>
     <string name="pair_rename_label">ନୌ</string>
     <string name="pair_retire_title">ଈ ଜୋଡ଼ି ଛେଡ଼ା କିଡ଼ୁ</string>

--- a/app/src/main/res/values-b+kxv+Orya/strings.xml
+++ b/app/src/main/res/values-b+kxv+Orya/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ଏକ ଚାର୍ଜ ମୁଦେ</string>
     <string name="pair_cycles">ଚକ୍ର</string>
     <string name="pair_charge_watched">ଦେଖ୍‌ତେ</string>
+    <string name="pair_vs_new">ନୱା ବେଲ୍‌ତେ</string>
     <string name="pair_cycle_number">ଚକ୍ର %1$d</string>
     <string name="pair_rename_title">ଜୋଡ଼ି-ନା ନୌ ବାଦାଲା କିଡ଼ୁ</string>
     <string name="pair_rename_label">ନୌ</string>

--- a/app/src/main/res/values-b+kxv+Telu/strings.xml
+++ b/app/src/main/res/values-b+kxv+Telu/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ప్రాతి ఘాన్తా</string>
     <string name="pair_bought">కినా ఆతే</string>
     <string name="pair_daily_hours_14">ప్రాతి దినా ఘాన్తా (14 దినా)</string>
+    <string name="pair_charge_cycles">చార్జ్ చక్ర</string>
+    <string name="pair_per_charge">ఏక్ చార్జ్ ముదె</string>
+    <string name="pair_cycles">చక్ర</string>
+    <string name="pair_charge_watched">దెఖ్‌తె</string>
+    <string name="pair_cycle_number">చక్ర %1$d</string>
     <string name="pair_rename_title">జోడి-నా నౌ బాదాలా కిడు</string>
     <string name="pair_rename_label">నౌ</string>
     <string name="pair_retire_title">ఈ జోడి ఛేడా కిడు</string>

--- a/app/src/main/res/values-b+kxv+Telu/strings.xml
+++ b/app/src/main/res/values-b+kxv+Telu/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ఏక్ చార్జ్ ముదె</string>
     <string name="pair_cycles">చక్ర</string>
     <string name="pair_charge_watched">దెఖ్‌తె</string>
+    <string name="pair_vs_new">నవా బెల్‌తె</string>
     <string name="pair_cycle_number">చక్ర %1$d</string>
     <string name="pair_rename_title">జోడి-నా నౌ బాదాలా కిడు</string>
     <string name="pair_rename_label">నౌ</string>

--- a/app/src/main/res/values-b+lij/strings.xml
+++ b/app/src/main/res/values-b+lij/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pe caregamento</string>
     <string name="pair_cycles">cicli</string>
     <string name="pair_charge_watched">osservou</string>
+    <string name="pair_vs_new">rispetto a neuve</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">cambya nome a-a pâriggia</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-b+lij/strings.xml
+++ b/app/src/main/res/values-b+lij/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per ora</string>
     <string name="pair_bought">compratô</string>
     <string name="pair_daily_hours_14">ore de giurni (14 giorni)</string>
+    <string name="pair_charge_cycles">cicli de caregamento</string>
+    <string name="pair_per_charge">pe caregamento</string>
+    <string name="pair_cycles">cicli</string>
+    <string name="pair_charge_watched">osservou</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">cambya nome a-a pâriggia</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">ritira tia pâriggia</string>

--- a/app/src/main/res/values-b+lkt/strings.xml
+++ b/app/src/main/res/values-b+lkt/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">wóiyokipȟaŋ waŋží</string>
     <string name="pair_cycles">wóiyokipȟaŋ</string>
     <string name="pair_charge_watched">wáŋyaŋkapi</string>
+    <string name="pair_vs_new">tȟetȟéča kiŋ él</string>
     <string name="pair_cycle_number">wóiyokipȟaŋ %1$d</string>
     <string name="pair_rename_title">napé kiŋ ti iyéchʼu</string>
     <string name="pair_rename_label">ti</string>

--- a/app/src/main/res/values-b+lkt/strings.xml
+++ b/app/src/main/res/values-b+lkt/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">opáwhte kiŋ</string>
     <string name="pair_bought">kiŋ</string>
     <string name="pair_daily_hours_14">aŋpétu opáwhte (aŋpétu akʼéšta)</string>
+    <string name="pair_charge_cycles">wóiyokipȟaŋ kiŋ</string>
+    <string name="pair_per_charge">wóiyokipȟaŋ waŋží</string>
+    <string name="pair_cycles">wóiyokipȟaŋ</string>
+    <string name="pair_charge_watched">wáŋyaŋkapi</string>
+    <string name="pair_cycle_number">wóiyokipȟaŋ %1$d</string>
     <string name="pair_rename_title">napé kiŋ ti iyéchʼu</string>
     <string name="pair_rename_label">ti</string>
     <string name="pair_retire_title">napé kiŋ kičʼúŋ</string>

--- a/app/src/main/res/values-b+lmo/strings.xml
+++ b/app/src/main/res/values-b+lmo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">par ora</string>
     <string name="pair_bought">comprada</string>
     <string name="pair_daily_hours_14">òre di dì (14 dì)</string>
+    <string name="pair_charge_cycles">cicli de carega</string>
+    <string name="pair_per_charge">per carega</string>
+    <string name="pair_cycles">cicli</string>
+    <string name="pair_charge_watched">osservaa</string>
+    <string name="pair_cycle_number">cicl %1$d</string>
     <string name="pair_rename_title">cambia nòm a la parea</string>
     <string name="pair_rename_label">nòm</string>
     <string name="pair_retire_title">messa via taa parea</string>

--- a/app/src/main/res/values-b+lmo/strings.xml
+++ b/app/src/main/res/values-b+lmo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per carega</string>
     <string name="pair_cycles">cicli</string>
     <string name="pair_charge_watched">osservaa</string>
+    <string name="pair_vs_new">respett a noeuv</string>
     <string name="pair_cycle_number">cicl %1$d</string>
     <string name="pair_rename_title">cambia nòm a la parea</string>
     <string name="pair_rename_label">nòm</string>

--- a/app/src/main/res/values-b+luo/strings.xml
+++ b/app/src/main/res/values-b+luo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kuom teko achiel</string>
     <string name="pair_cycles">lwenje</string>
     <string name="pair_charge_watched">mane one</string>
+    <string name="pair_vs_new">kipimo gi manyien</string>
     <string name="pair_cycle_number">lweny %1$d</string>
     <string name="pair_rename_title">lok nying hedfon</string>
     <string name="pair_rename_label">nying</string>

--- a/app/src/main/res/values-b+luo/strings.xml
+++ b/app/src/main/res/values-b+luo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">e saa achiel</string>
     <string name="pair_bought">nongiew</string>
     <string name="pair_daily_hours_14">saa mag odiechieng (ndalo 14)</string>
+    <string name="pair_charge_cycles">lwenje mag teko</string>
+    <string name="pair_per_charge">kuom teko achiel</string>
+    <string name="pair_cycles">lwenje</string>
+    <string name="pair_charge_watched">mane one</string>
+    <string name="pair_cycle_number">lweny %1$d</string>
     <string name="pair_rename_title">lok nying hedfon</string>
     <string name="pair_rename_label">nying</string>
     <string name="pair_retire_title">gol tich hedfon ni</string>

--- a/app/src/main/res/values-b+luy/strings.xml
+++ b/app/src/main/res/values-b+luy/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">khu maani kalala</string>
     <string name="pair_cycles">tsingira</string>
     <string name="pair_charge_watched">tsyalolwa</string>
+    <string name="pair_vs_new">khuparana nende tsiyakha</string>
     <string name="pair_cycle_number">ingira %1$d</string>
     <string name="pair_rename_title">kalushia elira lie bindu</string>
     <string name="pair_rename_label">elira</string>

--- a/app/src/main/res/values-b+luy/strings.xml
+++ b/app/src/main/res/values-b+luy/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">khu saa</string>
     <string name="pair_bought">shikulilwe</string>
     <string name="pair_daily_hours_14">tsisaa tsia buli inyanga (tsinyanga 14)</string>
+    <string name="pair_charge_cycles">tsingira tsie amaani</string>
+    <string name="pair_per_charge">khu maani kalala</string>
+    <string name="pair_cycles">tsingira</string>
+    <string name="pair_charge_watched">tsyalolwa</string>
+    <string name="pair_cycle_number">ingira %1$d</string>
     <string name="pair_rename_title">kalushia elira lie bindu</string>
     <string name="pair_rename_label">elira</string>
     <string name="pair_retire_title">rusia bindu bino mu mulimo</string>

--- a/app/src/main/res/values-b+mai/strings.xml
+++ b/app/src/main/res/values-b+mai/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रति घंटा</string>
     <string name="pair_bought">कीनल</string>
     <string name="pair_daily_hours_14">रोजक घंटा (१४ दिन)</string>
+    <string name="pair_charge_cycles">चार्ज चक्र</string>
+    <string name="pair_per_charge">प्रति चार्ज</string>
+    <string name="pair_cycles">चक्र</string>
+    <string name="pair_charge_watched">देखल गेल</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ीक नाम बदलू</string>
     <string name="pair_rename_label">नाम</string>
     <string name="pair_retire_title">एहि जोड़ीकेँ सेवानिवृत्त करू</string>

--- a/app/src/main/res/values-b+mai/strings.xml
+++ b/app/src/main/res/values-b+mai/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">प्रति चार्ज</string>
     <string name="pair_cycles">चक्र</string>
     <string name="pair_charge_watched">देखल गेल</string>
+    <string name="pair_vs_new">नव सँ तुलना मे</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ीक नाम बदलू</string>
     <string name="pair_rename_label">नाम</string>

--- a/app/src/main/res/values-b+mas/strings.xml
+++ b/app/src/main/res/values-b+mas/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">te saa</string>
     <string name="pair_bought">keiroro</string>
     <string name="pair_daily_hours_14">isaai e nkolong (nkolongi 14)</string>
+    <string name="pair_charge_cycles">inkishuita e nkijape</string>
+    <string name="pair_per_charge">te nkijape nabo</string>
+    <string name="pair_cycles">inkishuita</string>
+    <string name="pair_charge_watched">eitodolikinoto</string>
+    <string name="pair_cycle_number">enkishui %1$d</string>
     <string name="pair_rename_title">itayu enkarna e nkiyiaa</string>
     <string name="pair_rename_label">enkarna</string>
     <string name="pair_retire_title">itoroshi nkiyiaa ena</string>

--- a/app/src/main/res/values-b+mas/strings.xml
+++ b/app/src/main/res/values-b+mas/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">te nkijape nabo</string>
     <string name="pair_cycles">inkishuita</string>
     <string name="pair_charge_watched">eitodolikinoto</string>
+    <string name="pair_vs_new">te ng’ejuk</string>
     <string name="pair_cycle_number">enkishui %1$d</string>
     <string name="pair_rename_title">itayu enkarna e nkiyiaa</string>
     <string name="pair_rename_label">enkarna</string>

--- a/app/src/main/res/values-b+mer/strings.xml
+++ b/app/src/main/res/values-b+mer/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa inya imwe</string>
     <string name="pair_cycles">mithiuruko</string>
     <string name="pair_charge_watched">gwitirwa</string>
+    <string name="pair_vs_new">kũringithania na njeru</string>
     <string name="pair_cycle_number">muthiuruko %1$d</string>
     <string name="pair_rename_title">garũra rĩĩtwa rĩa kĩrĩndĩ</string>
     <string name="pair_rename_label">rĩĩtwa</string>

--- a/app/src/main/res/values-b+mer/strings.xml
+++ b/app/src/main/res/values-b+mer/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa ithaa</string>
     <string name="pair_bought">nĩkĩagũrirwo</string>
     <string name="pair_daily_hours_14">mathaa ma o mũthenya (thiku 14)</string>
+    <string name="pair_charge_cycles">mithiuruko ya inya</string>
+    <string name="pair_per_charge">kwa inya imwe</string>
+    <string name="pair_cycles">mithiuruko</string>
+    <string name="pair_charge_watched">gwitirwa</string>
+    <string name="pair_cycle_number">muthiuruko %1$d</string>
     <string name="pair_rename_title">garũra rĩĩtwa rĩa kĩrĩndĩ</string>
     <string name="pair_rename_label">rĩĩtwa</string>
     <string name="pair_retire_title">thiria kĩrĩndĩ gĩkĩ wĩra</string>

--- a/app/src/main/res/values-b+mfe/strings.xml
+++ b/app/src/main/res/values-b+mfe/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">par ler</string>
     <string name="pair_bought">aste</string>
     <string name="pair_daily_hours_14">ler par zour (14 zour)</string>
+    <string name="pair_charge_cycles">sik sarz</string>
+    <string name="pair_per_charge">par sarz</string>
+    <string name="pair_cycles">sik</string>
+    <string name="pair_charge_watched">obzerve</string>
+    <string name="pair_cycle_number">sik %1$d</string>
     <string name="pair_rename_title">sanz nom per</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">met sa per la dan retret</string>

--- a/app/src/main/res/values-b+mfe/strings.xml
+++ b/app/src/main/res/values-b+mfe/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">par sarz</string>
     <string name="pair_cycles">sik</string>
     <string name="pair_charge_watched">obzerve</string>
+    <string name="pair_vs_new">konpare ar nef</string>
     <string name="pair_cycle_number">sik %1$d</string>
     <string name="pair_rename_title">sanz nom per</string>
     <string name="pair_rename_label">nom</string>

--- a/app/src/main/res/values-b+mgh/strings.xml
+++ b/app/src/main/res/values-b+mgh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">khu ehora</string>
     <string name="pair_bought">wathumiwa</string>
     <string name="pair_daily_hours_14">mahora a nihiku (mahiku 14)</string>
+    <string name="pair_charge_cycles">mazungulusho a inguvu</string>
+    <string name="pair_per_charge">ni inguvu imosa</string>
+    <string name="pair_cycles">mazungulusho</string>
+    <string name="pair_charge_watched">yoonihiwa</string>
+    <string name="pair_cycle_number">nzungulusho %1$d</string>
     <string name="pair_rename_title">olukiha nsina na ifone</string>
     <string name="pair_rename_label">nsina</string>
     <string name="pair_retire_title">muhiyeke ifone ela</string>

--- a/app/src/main/res/values-b+mgh/strings.xml
+++ b/app/src/main/res/values-b+mgh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ni inguvu imosa</string>
     <string name="pair_cycles">mazungulusho</string>
     <string name="pair_charge_watched">yoonihiwa</string>
+    <string name="pair_vs_new">olinganihiwa ni yasyaka</string>
     <string name="pair_cycle_number">nzungulusho %1$d</string>
     <string name="pair_rename_title">olukiha nsina na ifone</string>
     <string name="pair_rename_label">nsina</string>

--- a/app/src/main/res/values-b+mgo/strings.xml
+++ b/app/src/main/res/values-b+mgo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ntsə mɔ́</string>
     <string name="pair_cycles">sikəl</string>
     <string name="pair_charge_watched">à zɨ</string>
+    <string name="pair_vs_new">nɛ́ fyɛ</string>
     <string name="pair_cycle_number">sikəl %1$d</string>
     <string name="pair_rename_title">tsə́ ndzɨ́ŋ zɨ ŋgáŋ</string>
     <string name="pair_rename_label">ndzɨ́ŋ</string>

--- a/app/src/main/res/values-b+mgo/strings.xml
+++ b/app/src/main/res/values-b+mgo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">nə ntɨɨ</string>
     <string name="pair_bought">ndzú</string>
     <string name="pair_daily_hours_14">ntɨɨ zɨ ŋwɔ́ŋ (ŋwɔ́ŋ 14)</string>
+    <string name="pair_charge_cycles">sikəl mə ntsə</string>
+    <string name="pair_per_charge">ntsə mɔ́</string>
+    <string name="pair_cycles">sikəl</string>
+    <string name="pair_charge_watched">à zɨ</string>
+    <string name="pair_cycle_number">sikəl %1$d</string>
     <string name="pair_rename_title">tsə́ ndzɨ́ŋ zɨ ŋgáŋ</string>
     <string name="pair_rename_label">ndzɨ́ŋ</string>
     <string name="pair_retire_title">tsɔ́ŋ ŋgáŋ zə</string>

--- a/app/src/main/res/values-b+mni/strings.xml
+++ b/app/src/main/res/values-b+mni/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ꯆꯥꯔꯖ ꯑꯃꯗ</string>
     <string name="pair_cycles">ꯆꯛꯔ</string>
     <string name="pair_charge_watched">ꯌꯦꯡꯈꯤꯕ</string>
+    <string name="pair_vs_new">ꯑꯅꯧꯕ ꯑꯗꯨꯒ ꯆꯥꯡꯗꯝꯅꯕꯗ</string>
     <string name="pair_cycle_number">ꯆꯛꯔ %1$d</string>
     <string name="pair_rename_title">হেদফোনগী মিং হোংদোকপা</string>
     <string name="pair_rename_label">মিং</string>

--- a/app/src/main/res/values-b+mni/strings.xml
+++ b/app/src/main/res/values-b+mni/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">পুং অমগী</string>
     <string name="pair_bought">লৈখ্রে</string>
     <string name="pair_daily_hours_14">নুমিৎ খুদিংগী পুং (নুমিৎ ১৪)</string>
+    <string name="pair_charge_cycles">ꯆꯥꯔꯖ ꯆꯛꯔ</string>
+    <string name="pair_per_charge">ꯆꯥꯔꯖ ꯑꯃꯗ</string>
+    <string name="pair_cycles">ꯆꯛꯔ</string>
+    <string name="pair_charge_watched">ꯌꯦꯡꯈꯤꯕ</string>
+    <string name="pair_cycle_number">ꯆꯛꯔ %1$d</string>
     <string name="pair_rename_title">হেদফোনগী মিং হোংদোকপা</string>
     <string name="pair_rename_label">মিং</string>
     <string name="pair_retire_title">হেদফোন অসি লোয়শিনবা</string>

--- a/app/src/main/res/values-b+mzn/strings.xml
+++ b/app/src/main/res/values-b+mzn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">در ساعت</string>
     <string name="pair_bought">خریداری</string>
     <string name="pair_daily_hours_14">ساعات روزانه (14 روز)</string>
+    <string name="pair_charge_cycles">شارژ چرخه‌ئون</string>
+    <string name="pair_per_charge">هر شارژ ره</string>
+    <string name="pair_cycles">چرخه‌ئون</string>
+    <string name="pair_charge_watched">دیه بیه</string>
+    <string name="pair_cycle_number">چرخه %1$d</string>
     <string name="pair_rename_title">تغییر نام جفت</string>
     <string name="pair_rename_label">نام</string>
     <string name="pair_retire_title">بازنشست این جفت</string>

--- a/app/src/main/res/values-b+mzn/strings.xml
+++ b/app/src/main/res/values-b+mzn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">هر شارژ ره</string>
     <string name="pair_cycles">چرخه‌ئون</string>
     <string name="pair_charge_watched">دیه بیه</string>
+    <string name="pair_vs_new">نو وقت ره نسبت</string>
     <string name="pair_cycle_number">چرخه %1$d</string>
     <string name="pair_rename_title">تغییر نام جفت</string>
     <string name="pair_rename_label">نام</string>

--- a/app/src/main/res/values-b+naq/strings.xml
+++ b/app/src/main/res/values-b+naq/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">mâ ǀgâub hoab ai</string>
     <string name="pair_cycles">ǃnâdi</string>
     <string name="pair_charge_watched">kōhes ge</string>
+    <string name="pair_vs_new">ǀasan ge i</string>
     <string name="pair_cycle_number">ǃnâ %1$d</string>
     <string name="pair_rename_title">ǂao ǃares tsi</string>
     <string name="pair_rename_label">tsi</string>

--- a/app/src/main/res/values-b+naq/strings.xml
+++ b/app/src/main/res/values-b+naq/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">hora by</string>
     <string name="pair_bought">guba</string>
     <string name="pair_daily_hours_14">ǂo-hora tsi (14 ǁau)</string>
+    <string name="pair_charge_cycles">ǀgâuǃnâdi</string>
+    <string name="pair_per_charge">mâ ǀgâub hoab ai</string>
+    <string name="pair_cycles">ǃnâdi</string>
+    <string name="pair_charge_watched">kōhes ge</string>
+    <string name="pair_cycle_number">ǃnâ %1$d</string>
     <string name="pair_rename_title">ǂao ǃares tsi</string>
     <string name="pair_rename_label">tsi</string>
     <string name="pair_retire_title">ǃaba ǃares di</string>

--- a/app/src/main/res/values-b+nds/strings.xml
+++ b/app/src/main/res/values-b+nds/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro laden</string>
     <string name="pair_cycles">zyklen</string>
     <string name="pair_charge_watched">beobacht</string>
+    <string name="pair_vs_new">gegen nieg</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ander nomen geven</string>
     <string name="pair_rename_label">nomen</string>

--- a/app/src/main/res/values-b+nds/strings.xml
+++ b/app/src/main/res/values-b+nds/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per our</string>
     <string name="pair_bought">kocht</string>
     <string name="pair_daily_hours_14">daaglike ouren (14 daag)</string>
+    <string name="pair_charge_cycles">laadzyklen</string>
+    <string name="pair_per_charge">pro laden</string>
+    <string name="pair_cycles">zyklen</string>
+    <string name="pair_charge_watched">beobacht</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ander nomen geven</string>
     <string name="pair_rename_label">nomen</string>
     <string name="pair_retire_title">dit paar pensioneren</string>

--- a/app/src/main/res/values-b+nnh/strings.xml
+++ b/app/src/main/res/values-b+nnh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">mfɔ́ ywǐ</string>
     <string name="pair_cycles">sikɛl</string>
     <string name="pair_charge_watched">wɛ̌n</string>
+    <string name="pair_vs_new">nɛ́ fyɛ́</string>
     <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">ghɔ ghɔ ghɔŋ ye</string>
     <string name="pair_rename_label">ghɔŋ</string>

--- a/app/src/main/res/values-b+nnh/strings.xml
+++ b/app/src/main/res/values-b+nnh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">nkɛp kə</string>
     <string name="pair_bought">kə</string>
     <string name="pair_daily_hours_14">a tɛ nkɛp (14 ŋgə)</string>
+    <string name="pair_charge_cycles">sikɛl mfɔ́</string>
+    <string name="pair_per_charge">mfɔ́ ywǐ</string>
+    <string name="pair_cycles">sikɛl</string>
+    <string name="pair_charge_watched">wɛ̌n</string>
+    <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">ghɔ ghɔ ghɔŋ ye</string>
     <string name="pair_rename_label">ghɔŋ</string>
     <string name="pair_retire_title">ghɔ ghɔ nka nkɔ</string>

--- a/app/src/main/res/values-b+nqo/strings.xml
+++ b/app/src/main/res/values-b+nqo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ߦߌߟߌ ߞߐ</string>
     <string name="pair_bought">ߛߊߊߙߊ</string>
     <string name="pair_daily_hours_14">ߘߏ߲ ߦߌߟߌ (14 ߣߊ)</string>
+    <string name="pair_charge_cycles">ߝߊ߲߬ߞߊ߬ ߞߎߘߊߦߌߘߊ</string>
+    <string name="pair_per_charge">ߝߊ߲߬ߞߊ߬ ߞߋߟߋ߲߫</string>
+    <string name="pair_cycles">ߞߎߘߊߦߌߘߊ</string>
+    <string name="pair_charge_watched">ߊ߬ ߝߟߍ߬ߣߍ߲</string>
+    <string name="pair_cycle_number">ߞߎߘߊߦߌߘߊ %1$d</string>
     <string name="pair_rename_title">ߞߍ ߛߋ ߘߌ߲ ߦߋ</string>
     <string name="pair_rename_label">ߘߌ߲</string>
     <string name="pair_retire_title">ߞߍ ߛߋ ߣߞߊ ߘߊߟߌ</string>

--- a/app/src/main/res/values-b+nqo/strings.xml
+++ b/app/src/main/res/values-b+nqo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ߝߊ߲߬ߞߊ߬ ߞߋߟߋ߲߫</string>
     <string name="pair_cycles">ߞߎߘߊߦߌߘߊ</string>
     <string name="pair_charge_watched">ߊ߬ ߝߟߍ߬ߣߍ߲</string>
+    <string name="pair_vs_new">ߞߎߘߊ ߡߊ߬</string>
     <string name="pair_cycle_number">ߞߎߘߊߦߌߘߊ %1$d</string>
     <string name="pair_rename_title">ߞߍ ߛߋ ߘߌ߲ ߦߋ</string>
     <string name="pair_rename_label">ߘߌ߲</string>

--- a/app/src/main/res/values-b+pa+Arab/strings.xml
+++ b/app/src/main/res/values-b+pa+Arab/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ہر چارج تے</string>
     <string name="pair_cycles">چکر</string>
     <string name="pair_charge_watched">ویکھیا</string>
+    <string name="pair_vs_new">نویں دے مقابلے</string>
     <string name="pair_cycle_number">چکر %1$d</string>
     <string name="pair_rename_title">جوڑی دا ناں بدلو</string>
     <string name="pair_rename_label">ناں</string>

--- a/app/src/main/res/values-b+pa+Arab/strings.xml
+++ b/app/src/main/res/values-b+pa+Arab/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">فی گھنٹہ</string>
     <string name="pair_bought">خریدیا</string>
     <string name="pair_daily_hours_14">روزانہ گھنٹے (14 دن)</string>
+    <string name="pair_charge_cycles">چارج چکر</string>
+    <string name="pair_per_charge">ہر چارج تے</string>
+    <string name="pair_cycles">چکر</string>
+    <string name="pair_charge_watched">ویکھیا</string>
+    <string name="pair_cycle_number">چکر %1$d</string>
     <string name="pair_rename_title">جوڑی دا ناں بدلو</string>
     <string name="pair_rename_label">ناں</string>
     <string name="pair_retire_title">ایہ جوڑا ریٹائر کرو</string>

--- a/app/src/main/res/values-b+pa+Guru/strings.xml
+++ b/app/src/main/res/values-b+pa+Guru/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ਹਰ ਚਾਰਜ ਤੇ</string>
     <string name="pair_cycles">ਚੱਕਰ</string>
     <string name="pair_charge_watched">ਵੇਖਿਆ</string>
+    <string name="pair_vs_new">ਨਵੇਂ ਦੇ ਮੁਕਾਬਲੇ</string>
     <string name="pair_cycle_number">ਚੱਕਰ %1$d</string>
     <string name="pair_rename_title">ਜੋੜੀ ਦਾ ਨਾਂ ਬਦਲੋ</string>
     <string name="pair_rename_label">ਨਾਂ</string>

--- a/app/src/main/res/values-b+pa+Guru/strings.xml
+++ b/app/src/main/res/values-b+pa+Guru/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ਪ੍ਰਤੀ ਘੰਟਾ</string>
     <string name="pair_bought">ਖਰੀਦਿਆ</string>
     <string name="pair_daily_hours_14">ਰੋਜ਼ਾਨਾ ਘੰਟੇ (14 ਦਿਨ)</string>
+    <string name="pair_charge_cycles">ਚਾਰਜ ਚੱਕਰ</string>
+    <string name="pair_per_charge">ਹਰ ਚਾਰਜ ਤੇ</string>
+    <string name="pair_cycles">ਚੱਕਰ</string>
+    <string name="pair_charge_watched">ਵੇਖਿਆ</string>
+    <string name="pair_cycle_number">ਚੱਕਰ %1$d</string>
     <string name="pair_rename_title">ਜੋੜੀ ਦਾ ਨਾਂ ਬਦਲੋ</string>
     <string name="pair_rename_label">ਨਾਂ</string>
     <string name="pair_retire_title">ਇਹ ਜੋੜਾ ਸੇਵਾਮੁਕਤ ਕਰੋ</string>

--- a/app/src/main/res/values-b+pcm/strings.xml
+++ b/app/src/main/res/values-b+pcm/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">for one charge</string>
     <string name="pair_cycles">cycle dem</string>
     <string name="pair_charge_watched">wetin we see</string>
+    <string name="pair_vs_new">compare to wen e new</string>
     <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">change di pair name</string>
     <string name="pair_rename_label">name</string>

--- a/app/src/main/res/values-b+pcm/strings.xml
+++ b/app/src/main/res/values-b+pcm/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per hour</string>
     <string name="pair_bought">when you buy am</string>
     <string name="pair_daily_hours_14">hours every day (14 days)</string>
+    <string name="pair_charge_cycles">charge cycle dem</string>
+    <string name="pair_per_charge">for one charge</string>
+    <string name="pair_cycles">cycle dem</string>
+    <string name="pair_charge_watched">wetin we see</string>
+    <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">change di pair name</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">retire dis pair</string>

--- a/app/src/main/res/values-b+prg/strings.xml
+++ b/app/src/main/res/values-b+prg/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per valandą</string>
     <string name="pair_bought">pirmas</string>
     <string name="pair_daily_hours_14">dienavandinės (14 dienų)</string>
+    <string name="pair_charge_cycles">ladīsnas cikla</string>
+    <string name="pair_per_charge">per ladīsnan</string>
+    <string name="pair_cycles">cikla</string>
+    <string name="pair_charge_watched">endirīts</string>
+    <string name="pair_cycle_number">ciklas %1$d</string>
     <string name="pair_rename_title">pervadinti pāra</string>
     <string name="pair_rename_label">vardas</string>
     <string name="pair_retire_title">pensėti tī pāra</string>

--- a/app/src/main/res/values-b+prg/strings.xml
+++ b/app/src/main/res/values-b+prg/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per ladīsnan</string>
     <string name="pair_cycles">cikla</string>
     <string name="pair_charge_watched">endirīts</string>
+    <string name="pair_vs_new">prei nauns</string>
     <string name="pair_cycle_number">ciklas %1$d</string>
     <string name="pair_rename_title">pervadinti pāra</string>
     <string name="pair_rename_label">vardas</string>

--- a/app/src/main/res/values-b+sah/strings.xml
+++ b/app/src/main/res/values-b+sah/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">биир уоскулатыыга</string>
     <string name="pair_cycles">эргиирдэр</string>
     <string name="pair_charge_watched">көрүллүбүт</string>
+    <string name="pair_vs_new">саҥа эрдэҕинээҕи</string>
     <string name="pair_cycle_number">эргиир %1$d</string>
     <string name="pair_rename_title">пара аатын уларыт</string>
     <string name="pair_rename_label">аат</string>

--- a/app/src/main/res/values-b+sah/strings.xml
+++ b/app/src/main/res/values-b+sah/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">чааска</string>
     <string name="pair_bought">атыыласпыт</string>
     <string name="pair_daily_hours_14">күҥҥэ чаастар (14 күн)</string>
+    <string name="pair_charge_cycles">уоскулатыы эргииринэн</string>
+    <string name="pair_per_charge">биир уоскулатыыга</string>
+    <string name="pair_cycles">эргиирдэр</string>
+    <string name="pair_charge_watched">көрүллүбүт</string>
+    <string name="pair_cycle_number">эргиир %1$d</string>
     <string name="pair_rename_title">пара аатын уларыт</string>
     <string name="pair_rename_label">аат</string>
     <string name="pair_retire_title">бу параны тохтот</string>

--- a/app/src/main/res/values-b+saq/strings.xml
+++ b/app/src/main/res/values-b+saq/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">a-saati i-moji</string>
     <string name="pair_bought">a-li-nunua</string>
     <string name="pair_daily_hours_14">n-toga a-saati (14 i-kitoni)</string>
+    <string name="pair_charge_cycles">nkilikilyata e nkere</string>
+    <string name="pair_per_charge">te nkere naapo</string>
+    <string name="pair_cycles">nkilikilyata</string>
+    <string name="pair_charge_watched">keitodoliki</string>
+    <string name="pair_cycle_number">nkilikilya %1$d</string>
     <string name="pair_rename_title">e-karata atin e-muoma</string>
     <string name="pair_rename_label">atin</string>
     <string name="pair_retire_title">a-buri e-muoma</string>

--- a/app/src/main/res/values-b+saq/strings.xml
+++ b/app/src/main/res/values-b+saq/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">te nkere naapo</string>
     <string name="pair_cycles">nkilikilyata</string>
     <string name="pair_charge_watched">keitodoliki</string>
+    <string name="pair_vs_new">te nkuchunga</string>
     <string name="pair_cycle_number">nkilikilya %1$d</string>
     <string name="pair_rename_title">e-karata atin e-muoma</string>
     <string name="pair_rename_label">atin</string>

--- a/app/src/main/res/values-b+sat/strings.xml
+++ b/app/src/main/res/values-b+sat/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ᱢᱤᱫ ᱴᱟᱲᱟᱝ ᱨᱮ</string>
     <string name="pair_bought">ᱠᱤᱨᱤᱧ ᱟᱠᱟᱱ</string>
     <string name="pair_daily_hours_14">ᱢᱟᱦᱟ ᱨᱮᱭᱟᱜ ᱴᱟᱲᱟᱝ (14 ᱢᱟᱦᱟ)</string>
+    <string name="pair_charge_cycles">ᱪᱟᱨᱡᱽ ᱪᱚᱠᱨᱟ</string>
+    <string name="pair_per_charge">ᱢᱤᱫ ᱪᱟᱨᱡᱽ ᱨᱮ</string>
+    <string name="pair_cycles">ᱪᱚᱠᱨᱟ</string>
+    <string name="pair_charge_watched">ᱧᱮᱞ ᱠᱟᱱᱟ</string>
+    <string name="pair_cycle_number">ᱪᱚᱠᱨᱟ %1$d</string>
     <string name="pair_rename_title">ᱡᱚᱲᱟ ᱨᱮᱭᱟᱜ ᱧᱩᱛᱩᱢ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <string name="pair_rename_label">ᱧᱩᱛᱩᱢ</string>
     <string name="pair_retire_title">ᱱᱚᱶᱟ ᱡᱚᱲᱟ ᱵᱟᱹᱭ ᱢᱮ</string>

--- a/app/src/main/res/values-b+sat/strings.xml
+++ b/app/src/main/res/values-b+sat/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ᱢᱤᱫ ᱪᱟᱨᱡᱽ ᱨᱮ</string>
     <string name="pair_cycles">ᱪᱚᱠᱨᱟ</string>
     <string name="pair_charge_watched">ᱧᱮᱞ ᱠᱟᱱᱟ</string>
+    <string name="pair_vs_new">ᱱᱟᱶᱟ ᱠᱷᱚᱱ</string>
     <string name="pair_cycle_number">ᱪᱚᱠᱨᱟ %1$d</string>
     <string name="pair_rename_title">ᱡᱚᱲᱟ ᱨᱮᱭᱟᱜ ᱧᱩᱛᱩᱢ ᱵᱚᱫᱚᱞ ᱢᱮ</string>
     <string name="pair_rename_label">ᱧᱩᱛᱩᱢ</string>

--- a/app/src/main/res/values-b+sbp/strings.xml
+++ b/app/src/main/res/values-b+sbp/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pa ingufu jimo</string>
     <string name="pair_cycles">ifisyunguluko</string>
     <string name="pair_charge_watched">fyalolilwe</string>
+    <string name="pair_vs_new">pa kulinganisya ni fipya</string>
     <string name="pair_cycle_number">ikisyunguluko %1$d</string>
     <string name="pair_rename_title">jua nena-ni amagabwa</string>
     <string name="pair_rename_label">nena</string>

--- a/app/src/main/res/values-b+sbp/strings.xml
+++ b/app/src/main/res/values-b+sbp/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kila saa</string>
     <string name="pair_bought">kulipwa</string>
     <string name="pair_daily_hours_14">masaa ya kila siku (mila 14)</string>
+    <string name="pair_charge_cycles">ifisyunguluko fya ingufu</string>
+    <string name="pair_per_charge">pa ingufu jimo</string>
+    <string name="pair_cycles">ifisyunguluko</string>
+    <string name="pair_charge_watched">fyalolilwe</string>
+    <string name="pair_cycle_number">ikisyunguluko %1$d</string>
     <string name="pair_rename_title">jua nena-ni amagabwa</string>
     <string name="pair_rename_label">nena</string>
     <string name="pair_retire_title">kushangalia amagabwa agaale</string>

--- a/app/src/main/res/values-b+sd+Arab/strings.xml
+++ b/app/src/main/res/values-b+sd+Arab/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">في ڪلاڪ</string>
     <string name="pair_bought">خريدو</string>
     <string name="pair_daily_hours_14">روزانہ ڪلاڪ (14 ڏينهن)</string>
+    <string name="pair_charge_cycles">چارج چڪر</string>
+    <string name="pair_per_charge">في چارج</string>
+    <string name="pair_cycles">چڪر</string>
+    <string name="pair_charge_watched">ڏٺو ويو</string>
+    <string name="pair_cycle_number">چڪر %1$d</string>
     <string name="pair_rename_title">جوڙي کو نام دوبارہ ڏيو</string>
     <string name="pair_rename_label">نام</string>
     <string name="pair_retire_title">هن جوڙي کو ريٽائر ڪريو</string>

--- a/app/src/main/res/values-b+sd+Arab/strings.xml
+++ b/app/src/main/res/values-b+sd+Arab/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">في چارج</string>
     <string name="pair_cycles">چڪر</string>
     <string name="pair_charge_watched">ڏٺو ويو</string>
+    <string name="pair_vs_new">نئين جي مقابلي ۾</string>
     <string name="pair_cycle_number">چڪر %1$d</string>
     <string name="pair_rename_title">جوڙي کو نام دوبارہ ڏيو</string>
     <string name="pair_rename_label">نام</string>

--- a/app/src/main/res/values-b+seh/strings.xml
+++ b/app/src/main/res/values-b+seh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pa mphambvu ibodzi</string>
     <string name="pair_cycles">mazungulusso</string>
     <string name="pair_charge_watched">asaoniwa</string>
+    <string name="pair_vs_new">kuyerezera na zipswa</string>
     <string name="pair_cycle_number">zungulusso %1$d</string>
     <string name="pair_rename_title">sinthani dzina la makedzeni</string>
     <string name="pair_rename_label">dzina</string>

--- a/app/src/main/res/values-b+seh/strings.xml
+++ b/app/src/main/res/values-b+seh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pa hora</string>
     <string name="pair_bought">kogula</string>
     <string name="pair_daily_hours_14">maola a tsiku (masiku 14)</string>
+    <string name="pair_charge_cycles">mazungulusso a mphambvu</string>
+    <string name="pair_per_charge">pa mphambvu ibodzi</string>
+    <string name="pair_cycles">mazungulusso</string>
+    <string name="pair_charge_watched">asaoniwa</string>
+    <string name="pair_cycle_number">zungulusso %1$d</string>
     <string name="pair_rename_title">sinthani dzina la makedzeni</string>
     <string name="pair_rename_label">dzina</string>
     <string name="pair_retire_title">asintha makedzeni ano</string>

--- a/app/src/main/res/values-b+ses/strings.xml
+++ b/app/src/main/res/values-b+ses/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">demiya koy</string>
     <string name="pair_bought">jara</string>
     <string name="pair_daily_hours_14">jiyaaru demiya jiyaaru 14 ga</string>
+    <string name="pair_charge_cycles">gaabu windiyaŋ</string>
+    <string name="pair_per_charge">gaabu fooda ga</string>
+    <string name="pair_cycles">windiyaŋ</string>
+    <string name="pair_charge_watched">i guna</string>
+    <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">koydameeyan tuma sanda</string>
     <string name="pair_rename_label">tuma</string>
     <string name="pair_retire_title">koydameeyan ni kafa</string>

--- a/app/src/main/res/values-b+ses/strings.xml
+++ b/app/src/main/res/values-b+ses/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">gaabu fooda ga</string>
     <string name="pair_cycles">windiyaŋ</string>
     <string name="pair_charge_watched">i guna</string>
+    <string name="pair_vs_new">taasi nda tajji</string>
     <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">koydameeyan tuma sanda</string>
     <string name="pair_rename_label">tuma</string>

--- a/app/src/main/res/values-b+smn/strings.xml
+++ b/app/src/main/res/values-b+smn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">jahka</string>
     <string name="pair_bought">ostetam</string>
     <string name="pair_daily_hours_14">juohke-aige jahkaj (14 pájvvá)</string>
+    <string name="pair_charge_cycles">luâđâmsyklusah</string>
+    <string name="pair_per_charge">ohtâ luâđâm</string>
+    <string name="pair_cycles">syklusah</string>
+    <string name="pair_charge_watched">táárum</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">maajje-nimá pair</string>
     <string name="pair_rename_label">nimá</string>
     <string name="pair_retire_title">maahta tánná pair</string>

--- a/app/src/main/res/values-b+smn/strings.xml
+++ b/app/src/main/res/values-b+smn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ohtâ luâđâm</string>
     <string name="pair_cycles">syklusah</string>
     <string name="pair_charge_watched">táárum</string>
+    <string name="pair_vs_new">ođđâsij verdo</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">maajje-nimá pair</string>
     <string name="pair_rename_label">nimá</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">по сату</string>
     <string name="pair_bought">купљено</string>
     <string name="pair_daily_hours_14">дневних сати (14 дана)</string>
+    <string name="pair_charge_cycles">циклуси пуњења</string>
+    <string name="pair_per_charge">по пуњењу</string>
+    <string name="pair_cycles">циклуси</string>
+    <string name="pair_charge_watched">посматрано</string>
+    <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>
     <string name="pair_retire_title">пензионирај овај пар</string>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">по пуњењу</string>
     <string name="pair_cycles">циклуси</string>
     <string name="pair_charge_watched">посматрано</string>
+    <string name="pair_vs_new">у односу на нове</string>
     <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">po satu</string>
     <string name="pair_bought">kupljeno</string>
     <string name="pair_daily_hours_14">dnevni sati (14 dana)</string>
+    <string name="pair_charge_cycles">ciklusi punjenja</string>
+    <string name="pair_per_charge">po punjenju</string>
+    <string name="pair_cycles">ciklusi</string>
+    <string name="pair_charge_watched">posmatrano</string>
+    <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">penzioniši ovaj par</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">po punjenju</string>
     <string name="pair_cycles">ciklusi</string>
     <string name="pair_charge_watched">posmatrano</string>
+    <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>

--- a/app/src/main/res/values-b+syr/strings.xml
+++ b/app/src/main/res/values-b+syr/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ܠܫܥܬܐ</string>
     <string name="pair_bought">ܙܒܝܢܐ</string>
     <string name="pair_daily_hours_14">ܫܥܐ ܕܟܠܝܘܡ (14 ܝܘܡܐ)</string>
+    <string name="pair_charge_cycles">ܟܪ̈ܘܟܝܐ ܕܡܠܝܬܐ</string>
+    <string name="pair_per_charge">ܠܟܠ ܡܠܝܬܐ</string>
+    <string name="pair_cycles">ܟܪ̈ܘܟܝܐ</string>
+    <string name="pair_charge_watched">ܡܬܚܙܝܢܐ</string>
+    <string name="pair_cycle_number">ܟܪܘܟܝܐ %1$d</string>
     <string name="pair_rename_title">ܫܚܠܦ ܫܡܐ ܕܙܘܓܐ</string>
     <string name="pair_rename_label">ܫܡܐ</string>
     <string name="pair_retire_title">ܐܢܝܚ ܗܢܐ ܙܘܓܐ</string>

--- a/app/src/main/res/values-b+syr/strings.xml
+++ b/app/src/main/res/values-b+syr/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ܠܟܠ ܡܠܝܬܐ</string>
     <string name="pair_cycles">ܟܪ̈ܘܟܝܐ</string>
     <string name="pair_charge_watched">ܡܬܚܙܝܢܐ</string>
+    <string name="pair_vs_new">ܥܡ ܚܕ̈ܬܐ</string>
     <string name="pair_cycle_number">ܟܪܘܟܝܐ %1$d</string>
     <string name="pair_rename_title">ܫܚܠܦ ܫܡܐ ܕܙܘܓܐ</string>
     <string name="pair_rename_label">ܫܡܐ</string>

--- a/app/src/main/res/values-b+szl/strings.xml
+++ b/app/src/main/res/values-b+szl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">na godzina</string>
     <string name="pair_bought">kupiōne</string>
     <string name="pair_daily_hours_14">godziny na dziyń (14 dni)</string>
+    <string name="pair_charge_cycles">cykle ladowanio</string>
+    <string name="pair_per_charge">na ladowanie</string>
+    <string name="pair_cycles">cykle</string>
+    <string name="pair_charge_watched">ôbserwowane</string>
+    <string name="pair_cycle_number">cykel %1$d</string>
     <string name="pair_rename_title">przemianuj pora</string>
     <string name="pair_rename_label">miano</string>
     <string name="pair_retire_title">dej pynzyjo tymu pora</string>

--- a/app/src/main/res/values-b+szl/strings.xml
+++ b/app/src/main/res/values-b+szl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na ladowanie</string>
     <string name="pair_cycles">cykle</string>
     <string name="pair_charge_watched">ôbserwowane</string>
+    <string name="pair_vs_new">w porōwnaniu z nowymi</string>
     <string name="pair_cycle_number">cykel %1$d</string>
     <string name="pair_rename_title">przemianuj pora</string>
     <string name="pair_rename_label">miano</string>

--- a/app/src/main/res/values-b+teo/strings.xml
+++ b/app/src/main/res/values-b+teo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa apedor adiope</string>
     <string name="pair_cycles">aikalikalak</string>
     <string name="pair_charge_watched">eitodolikinos</string>
+    <string name="pair_vs_new">kwa aisisianakin ka ng’ini</string>
     <string name="pair_cycle_number">aikalikal %1$d</string>
     <string name="pair_rename_title">ilokikin ekiror loka apesur</string>
     <string name="pair_rename_label">ekiror</string>

--- a/app/src/main/res/values-b+teo/strings.xml
+++ b/app/src/main/res/values-b+teo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kanuka esawa</string>
     <string name="pair_bought">ikwenit</string>
     <string name="pair_daily_hours_14">isawan luka aparan (iparasia 14)</string>
+    <string name="pair_charge_cycles">aikalikalak nu apedor</string>
+    <string name="pair_per_charge">kwa apedor adiope</string>
+    <string name="pair_cycles">aikalikalak</string>
+    <string name="pair_charge_watched">eitodolikinos</string>
+    <string name="pair_cycle_number">aikalikal %1$d</string>
     <string name="pair_rename_title">ilokikin ekiror loka apesur</string>
     <string name="pair_rename_label">ekiror</string>
     <string name="pair_retire_title">itodoli apesur na</string>

--- a/app/src/main/res/values-b+twq/strings.xml
+++ b/app/src/main/res/values-b+twq/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">gaabu fooda ga</string>
     <string name="pair_cycles">windiyaŋ</string>
     <string name="pair_charge_watched">i guna</string>
+    <string name="pair_vs_new">taasi nda tajji</string>
     <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">gara maa sinda</string>
     <string name="pair_rename_label">maa</string>

--- a/app/src/main/res/values-b+twq/strings.xml
+++ b/app/src/main/res/values-b+twq/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">guuru ka</string>
     <string name="pair_bought">sanda goy</string>
     <string name="pair_daily_hours_14">guuru gida (caxe 14)</string>
+    <string name="pair_charge_cycles">gaabu windiyaŋ</string>
+    <string name="pair_per_charge">gaabu fooda ga</string>
+    <string name="pair_cycles">windiyaŋ</string>
+    <string name="pair_charge_watched">i guna</string>
+    <string name="pair_cycle_number">windi %1$d</string>
     <string name="pair_rename_title">gara maa sinda</string>
     <string name="pair_rename_label">maa</string>
     <string name="pair_retire_title">gara fay gonda</string>

--- a/app/src/main/res/values-b+tzm/strings.xml
+++ b/app/src/main/res/values-b+tzm/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ger tsrat</string>
     <string name="pair_bought">yuwsan</string>
     <string name="pair_daily_hours_14">tisrat n unebdu (ayyur 14)</string>
+    <string name="pair_charge_cycles">tiwinas n uccenṭi</string>
+    <string name="pair_per_charge">i yal accenṭi</string>
+    <string name="pair_cycles">tiwinas</string>
+    <string name="pair_charge_watched">ittwaẓer</string>
+    <string name="pair_cycle_number">tawinest %1$d</string>
     <string name="pair_rename_title">asgg izem n tmaza</string>
     <string name="pair_rename_label">izem</string>
     <string name="pair_retire_title">tutwi tmaza</string>

--- a/app/src/main/res/values-b+tzm/strings.xml
+++ b/app/src/main/res/values-b+tzm/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">i yal accenṭi</string>
     <string name="pair_cycles">tiwinas</string>
     <string name="pair_charge_watched">ittwaẓer</string>
+    <string name="pair_vs_new">ɣef wamek llan d imaynuten</string>
     <string name="pair_cycle_number">tawinest %1$d</string>
     <string name="pair_rename_title">asgg izem n tmaza</string>
     <string name="pair_rename_label">izem</string>

--- a/app/src/main/res/values-b+uz+Arab/strings.xml
+++ b/app/src/main/res/values-b+uz+Arab/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">سائات اۋقاتى</string>
     <string name="pair_bought">سیتیۋالغان</string>
     <string name="pair_daily_hours_14">کونلیك سائات (14 کون)</string>
+    <string name="pair_charge_cycles">قوۋۋت سیکللری</string>
+    <string name="pair_per_charge">ھر قوۋۋتگه</string>
+    <string name="pair_cycles">سیکللر</string>
+    <string name="pair_charge_watched">کوزتیلگن</string>
+    <string name="pair_cycle_number">سیکل %1$d</string>
     <string name="pair_rename_title">جوپنىڭ نامى ۆزگارت</string>
     <string name="pair_rename_label">نام</string>
     <string name="pair_retire_title">بو جوپنى پنسیودالاستو</string>

--- a/app/src/main/res/values-b+uz+Arab/strings.xml
+++ b/app/src/main/res/values-b+uz+Arab/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ھر قوۋۋتگه</string>
     <string name="pair_cycles">سیکللر</string>
     <string name="pair_charge_watched">کوزتیلگن</string>
+    <string name="pair_vs_new">یانگی ھولیگه نیسبتن</string>
     <string name="pair_cycle_number">سیکل %1$d</string>
     <string name="pair_rename_title">جوپنىڭ نامى ۆزگارت</string>
     <string name="pair_rename_label">نام</string>

--- a/app/src/main/res/values-b+uz+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+uz+Cyrl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">соат ўша</string>
     <string name="pair_bought">сотинди</string>
     <string name="pair_daily_hours_14">ҳар куннинг сўлари (14 куни)</string>
+    <string name="pair_charge_cycles">қувватлаш цикллари</string>
+    <string name="pair_per_charge">ҳар қувватлашга</string>
+    <string name="pair_cycles">цикллар</string>
+    <string name="pair_charge_watched">кузатилган</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жуфтни номи ўзгартириш</string>
     <string name="pair_rename_label">ном</string>
     <string name="pair_retire_title">бу жуфтни рахметдан қайдириш</string>

--- a/app/src/main/res/values-b+uz+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+uz+Cyrl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ҳар қувватлашга</string>
     <string name="pair_cycles">цикллар</string>
     <string name="pair_charge_watched">кузатилган</string>
+    <string name="pair_vs_new">янги ҳолига нисбатан</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жуфтни номи ўзгартириш</string>
     <string name="pair_rename_label">ном</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">soат usha</string>
     <string name="pair_bought">sotindi</string>
     <string name="pair_daily_hours_14">har kunning surlari (14 kuni)</string>
+    <string name="pair_charge_cycles">quvvatlash sikllari</string>
+    <string name="pair_per_charge">har quvvatlashga</string>
+    <string name="pair_cycles">sikllar</string>
+    <string name="pair_charge_watched">kuzatilgan</string>
+    <string name="pair_cycle_number">sikl %1$d</string>
     <string name="pair_rename_title">jufтni nomi ozgartirish</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">bu jufтni rahmetdan qaydir-ish</string>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">har quvvatlashga</string>
     <string name="pair_cycles">sikllar</string>
     <string name="pair_charge_watched">kuzatilgan</string>
+    <string name="pair_vs_new">yangi holiga nisbatan</string>
     <string name="pair_cycle_number">sikl %1$d</string>
     <string name="pair_rename_title">jufтni nomi ozgartirish</string>
     <string name="pair_rename_label">nom</string>

--- a/app/src/main/res/values-b+vec/strings.xml
+++ b/app/src/main/res/values-b+vec/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">par carga</string>
     <string name="pair_cycles">cicli</string>
     <string name="pair_charge_watched">osservà</string>
+    <string name="pair_vs_new">rispeto a nove</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">rinomina la para</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-b+vec/strings.xml
+++ b/app/src/main/res/values-b+vec/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per ora</string>
     <string name="pair_bought">comprao</string>
     <string name="pair_daily_hours_14">ore al giorno (14 giorni)</string>
+    <string name="pair_charge_cycles">cicli de carga</string>
+    <string name="pair_per_charge">par carga</string>
+    <string name="pair_cycles">cicli</string>
+    <string name="pair_charge_watched">osservà</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">rinomina la para</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">manda sto para in pensione</string>

--- a/app/src/main/res/values-b+wae/strings.xml
+++ b/app/src/main/res/values-b+wae/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pro stunda</string>
     <string name="pair_bought">kauft</string>
     <string name="pair_daily_hours_14">tägli stunda (14 tag)</string>
+    <string name="pair_charge_cycles">ladzyklä</string>
+    <string name="pair_per_charge">pro ladig</string>
+    <string name="pair_cycles">zyklä</string>
+    <string name="pair_charge_watched">bschaut</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">noma</string>
     <string name="pair_retire_title">däs paar ischtellee</string>

--- a/app/src/main/res/values-b+wae/strings.xml
+++ b/app/src/main/res/values-b+wae/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro ladig</string>
     <string name="pair_cycles">zyklä</string>
     <string name="pair_charge_watched">bschaut</string>
+    <string name="pair_vs_new">gegenüber nöi</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">noma</string>

--- a/app/src/main/res/values-b+xnr/strings.xml
+++ b/app/src/main/res/values-b+xnr/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">हर चार्ज पर</string>
     <string name="pair_cycles">चक्कर</string>
     <string name="pair_charge_watched">दिक्खेया</string>
+    <string name="pair_vs_new">नै दे मुकाबले</string>
     <string name="pair_cycle_number">चक्कर %1$d</string>
     <string name="pair_rename_title">जोड़ी दा नां बदलो</string>
     <string name="pair_rename_label">नां</string>

--- a/app/src/main/res/values-b+xnr/strings.xml
+++ b/app/src/main/res/values-b+xnr/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रति घंटा</string>
     <string name="pair_bought">खरीदी</string>
     <string name="pair_daily_hours_14">रोज़ दे घंटे (14 दिन)</string>
+    <string name="pair_charge_cycles">चार्ज चक्कर</string>
+    <string name="pair_per_charge">हर चार्ज पर</string>
+    <string name="pair_cycles">चक्कर</string>
+    <string name="pair_charge_watched">दिक्खेया</string>
+    <string name="pair_cycle_number">चक्कर %1$d</string>
     <string name="pair_rename_title">जोड़ी दा नां बदलो</string>
     <string name="pair_rename_label">नां</string>
     <string name="pair_retire_title">इसा जोड़ी गी रिटायर करो</string>

--- a/app/src/main/res/values-b+xog/strings.xml
+++ b/app/src/main/res/values-b+xog/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">buli saawa</string>
     <string name="pair_bought">guli</string>
     <string name="pair_daily_hours_14">saawa z’enday (ennaku 14)</string>
+    <string name="pair_charge_cycles">enkyukakyuka z’amaani</string>
+    <string name="pair_per_charge">ku maani agamu</string>
+    <string name="pair_cycles">enkyukakyuka</string>
+    <string name="pair_charge_watched">ebyalabwa</string>
+    <string name="pair_cycle_number">enkyukakyuka %1$d</string>
     <string name="pair_rename_title">gamba ensawo ngeri</string>
     <string name="pair_rename_label">erinnya</string>
     <string name="pair_retire_title">giriko ensawo eno</string>

--- a/app/src/main/res/values-b+xog/strings.xml
+++ b/app/src/main/res/values-b+xog/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ku maani agamu</string>
     <string name="pair_cycles">enkyukakyuka</string>
     <string name="pair_charge_watched">ebyalabwa</string>
+    <string name="pair_vs_new">nga bigeraageranyizibwa n’empya</string>
     <string name="pair_cycle_number">enkyukakyuka %1$d</string>
     <string name="pair_rename_title">gamba ensawo ngeri</string>
     <string name="pair_rename_label">erinnya</string>

--- a/app/src/main/res/values-b+yav/strings.xml
+++ b/app/src/main/res/values-b+yav/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ndáá yímɔ́</string>
     <string name="pair_cycles">sikɛl</string>
     <string name="pair_charge_watched">bá ɛ́ɛn</string>
+    <string name="pair_vs_new">nɛ́ mʉ́ndúm</string>
     <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">súk a kóm a ab ne</string>
     <string name="pair_rename_label">kóm</string>

--- a/app/src/main/res/values-b+yav/strings.xml
+++ b/app/src/main/res/values-b+yav/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">a tem muanda</string>
     <string name="pair_bought">a búe</string>
     <string name="pair_daily_hours_14">tem muanda (14 níe)</string>
+    <string name="pair_charge_cycles">sikɛl mʉ́ ndáá</string>
+    <string name="pair_per_charge">ndáá yímɔ́</string>
+    <string name="pair_cycles">sikɛl</string>
+    <string name="pair_charge_watched">bá ɛ́ɛn</string>
+    <string name="pair_cycle_number">sikɛl %1$d</string>
     <string name="pair_rename_title">súk a kóm a ab ne</string>
     <string name="pair_rename_label">kóm</string>
     <string name="pair_retire_title">níe a ab ne ánda</string>

--- a/app/src/main/res/values-b+yrl/strings.xml
+++ b/app/src/main/res/values-b+yrl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">yaskuari akanhẽ rupí</string>
     <string name="pair_bought">umumtima</string>
     <string name="pair_daily_hours_14">yaskuari irũma (14 ãwé-itá)</string>
+    <string name="pair_charge_cycles">sikuru karrega</string>
+    <string name="pair_per_charge">karrega yepé</string>
+    <string name="pair_cycles">sikuru</string>
+    <string name="pair_charge_watched">usemaã</string>
+    <string name="pair_cycle_number">sikuru %1$d</string>
     <string name="pair_rename_title">tamba retama umusuka</string>
     <string name="pair_rename_label">tamba</string>
     <string name="pair_retire_title">remá umusuka pite</string>

--- a/app/src/main/res/values-b+yrl/strings.xml
+++ b/app/src/main/res/values-b+yrl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">karrega yepé</string>
     <string name="pair_cycles">sikuru</string>
     <string name="pair_charge_watched">usemaã</string>
+    <string name="pair_vs_new">pyasu ariré</string>
     <string name="pair_cycle_number">sikuru %1$d</string>
     <string name="pair_rename_title">tamba retama umusuka</string>
     <string name="pair_rename_label">tamba</string>

--- a/app/src/main/res/values-b+yue+Hans/strings.xml
+++ b/app/src/main/res/values-b+yue+Hans/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">每次充电</string>
     <string name="pair_cycles">周期</string>
     <string name="pair_charge_watched">观察时长</string>
+    <string name="pair_vs_new">同全新时比</string>
     <string name="pair_cycle_number">周期 %1$d</string>
     <string name="pair_rename_title">重新命名耳机对</string>
     <string name="pair_rename_label">名称</string>

--- a/app/src/main/res/values-b+yue+Hans/strings.xml
+++ b/app/src/main/res/values-b+yue+Hans/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">每小时</string>
     <string name="pair_bought">购买</string>
     <string name="pair_daily_hours_14">每日小时数（14 日）</string>
+    <string name="pair_charge_cycles">充电周期</string>
+    <string name="pair_per_charge">每次充电</string>
+    <string name="pair_cycles">周期</string>
+    <string name="pair_charge_watched">观察时长</string>
+    <string name="pair_cycle_number">周期 %1$d</string>
     <string name="pair_rename_title">重新命名耳机对</string>
     <string name="pair_rename_label">名称</string>
     <string name="pair_retire_title">退休呢副耳机</string>

--- a/app/src/main/res/values-b+yue+Hant/strings.xml
+++ b/app/src/main/res/values-b+yue+Hant/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">每次充電</string>
     <string name="pair_cycles">週期</string>
     <string name="pair_charge_watched">觀察時長</string>
+    <string name="pair_vs_new">同全新時比</string>
     <string name="pair_cycle_number">週期 %1$d</string>
     <string name="pair_rename_title">重新命名耳機對</string>
     <string name="pair_rename_label">名稱</string>

--- a/app/src/main/res/values-b+yue+Hant/strings.xml
+++ b/app/src/main/res/values-b+yue+Hant/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">每小時</string>
     <string name="pair_bought">購買</string>
     <string name="pair_daily_hours_14">每日小時數（14 日）</string>
+    <string name="pair_charge_cycles">充電週期</string>
+    <string name="pair_per_charge">每次充電</string>
+    <string name="pair_cycles">週期</string>
+    <string name="pair_charge_watched">觀察時長</string>
+    <string name="pair_cycle_number">週期 %1$d</string>
     <string name="pair_rename_title">重新命名耳機對</string>
     <string name="pair_rename_label">名稱</string>
     <string name="pair_retire_title">退休呢副耳機</string>

--- a/app/src/main/res/values-b+zgh/strings.xml
+++ b/app/src/main/res/values-b+zgh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ⵢⵉⵙⴳⴳⴰⵙⵏ</string>
     <string name="pair_bought">ⵓⵙⴳⴳⵏ</string>
     <string name="pair_daily_hours_14">ⵢⵉⵙⴳⴳⴰⵙⵏ ⵏ ⵢⵉⵎⵖⵏⴰⵙⵏ (14 ⵢⵉⵙⴳⴳⴰⵙⵏ)</string>
+    <string name="pair_charge_cycles">ⵜⵉⵡⵉⵏⴰⵙ ⵏ ⵓⵛⴰⵔⵊⵉ</string>
+    <string name="pair_per_charge">ⵉ ⴽⵓ ⴰⵛⴰⵔⵊⵉ</string>
+    <string name="pair_cycles">ⵜⵉⵡⵉⵏⴰⵙ</string>
+    <string name="pair_charge_watched">ⵉⵜⵜⵡⴰⵥⵕ</string>
+    <string name="pair_cycle_number">ⵜⴰⵡⵉⵏⵙⵜ %1$d</string>
     <string name="pair_rename_title">ⵙⵏⵖⵍ ⵉⵙⵎ ⵏ ⵡⴳⴳⵓⵔ</string>
     <string name="pair_rename_label">ⵉⵙⵎ</string>
     <string name="pair_retire_title">ⵔⵔⴷ ⵡⴳⴳⵓⵔ ⵢⴰⴳⵉ</string>

--- a/app/src/main/res/values-b+zgh/strings.xml
+++ b/app/src/main/res/values-b+zgh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ⵉ ⴽⵓ ⴰⵛⴰⵔⵊⵉ</string>
     <string name="pair_cycles">ⵜⵉⵡⵉⵏⴰⵙ</string>
     <string name="pair_charge_watched">ⵉⵜⵜⵡⴰⵥⵕ</string>
+    <string name="pair_vs_new">ⵅⴼ ⵎⴰⵎⴽ ⵍⵍⴰⵏ ⴷ ⵉⵎⴰⵢⵏⵓⵜⵏ</string>
     <string name="pair_cycle_number">ⵜⴰⵡⵉⵏⵙⵜ %1$d</string>
     <string name="pair_rename_title">ⵙⵏⵖⵍ ⵉⵙⵎ ⵏ ⵡⴳⴳⵓⵔ</string>
     <string name="pair_rename_label">ⵉⵙⵎ</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">每次充电</string>
     <string name="pair_cycles">循环</string>
     <string name="pair_charge_watched">观察时长</string>
+    <string name="pair_vs_new">相比全新时</string>
     <string name="pair_cycle_number">第 %1$d 次循环</string>
     <string name="pair_rename_title">重命名耳机</string>
     <string name="pair_rename_label">名称</string>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">每小时</string>
     <string name="pair_bought">购买日期</string>
     <string name="pair_daily_hours_14">每日时长(14天)</string>
+    <string name="pair_charge_cycles">充电循环</string>
+    <string name="pair_per_charge">每次充电</string>
+    <string name="pair_cycles">循环</string>
+    <string name="pair_charge_watched">观察时长</string>
+    <string name="pair_cycle_number">第 %1$d 次循环</string>
     <string name="pair_rename_title">重命名耳机</string>
     <string name="pair_rename_label">名称</string>
     <string name="pair_retire_title">退役这副耳机</string>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_per_charge">每次充電</string>
     <string name="pair_cycles">循環</string>
     <string name="pair_charge_watched">觀察時長</string>
+    <string name="pair_vs_new">相比全新時</string>
     <string name="pair_cycle_number">第 %1$d 次循環</string>
     <string name="pair_rename_title">重新命名耳機</string>
     <string name="pair_rename_label">名稱</string>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -99,6 +99,11 @@
     <string name="pair_per_hour">每小時</string>
     <string name="pair_bought">購買於</string>
     <string name="pair_daily_hours_14">每日小時數（14 天）</string>
+    <string name="pair_charge_cycles">充電循環</string>
+    <string name="pair_per_charge">每次充電</string>
+    <string name="pair_cycles">循環</string>
+    <string name="pair_charge_watched">觀察時長</string>
+    <string name="pair_cycle_number">第 %1$d 次循環</string>
     <string name="pair_rename_title">重新命名耳機</string>
     <string name="pair_rename_label">名稱</string>
     <string name="pair_retire_title">將此耳機退役</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">на адзін зарад</string>
     <string name="pair_cycles">цыклы</string>
     <string name="pair_charge_watched">адсочана</string>
+    <string name="pair_vs_new">у параўнанні з новымі</string>
     <string name="pair_cycle_number">цыкл %1$d</string>
     <string name="pair_rename_title">перайменаваць пару</string>
     <string name="pair_rename_label">імя</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">за гадзіну</string>
     <string name="pair_bought">куплены</string>
     <string name="pair_daily_hours_14">гадзіны па днях (14 дзён)</string>
+    <string name="pair_charge_cycles">цыклы зарадкі</string>
+    <string name="pair_per_charge">на адзін зарад</string>
+    <string name="pair_cycles">цыклы</string>
+    <string name="pair_charge_watched">адсочана</string>
+    <string name="pair_cycle_number">цыкл %1$d</string>
     <string name="pair_rename_title">перайменаваць пару</string>
     <string name="pair_rename_label">імя</string>
     <string name="pair_retire_title">выключыце гэту пару</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">на зареждане</string>
     <string name="pair_cycles">цикли</string>
     <string name="pair_charge_watched">наблюдавано</string>
+    <string name="pair_vs_new">спрямо нови</string>
     <string name="pair_cycle_number">цикъл %1$d</string>
     <string name="pair_rename_title">преименуване на двойка</string>
     <string name="pair_rename_label">име</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">за час</string>
     <string name="pair_bought">закупени</string>
     <string name="pair_daily_hours_14">часове по дни (14 дни)</string>
+    <string name="pair_charge_cycles">цикли на зареждане</string>
+    <string name="pair_per_charge">на зареждане</string>
+    <string name="pair_cycles">цикли</string>
+    <string name="pair_charge_watched">наблюдавано</string>
+    <string name="pair_cycle_number">цикъл %1$d</string>
     <string name="pair_rename_title">преименуване на двойка</string>
     <string name="pair_rename_label">име</string>
     <string name="pair_retire_title">пенсионирайте тази двойка</string>

--- a/app/src/main/res/values-bm/strings.xml
+++ b/app/src/main/res/values-bm/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">kɔrɔ kɔ</string>
     <string name="pair_bought">satɛ kɛ</string>
     <string name="pair_daily_hours_14">kɔrɔ-juman (gɛrɛ 14)</string>
+    <string name="pair_charge_cycles">fanga siklo</string>
+    <string name="pair_per_charge">fanga kelen na</string>
+    <string name="pair_cycles">siklo</string>
+    <string name="pair_charge_watched">a filɛra</string>
+    <string name="pair_cycle_number">siklo %1$d</string>
     <string name="pair_rename_title">kopila tɔgɔ sɛbɛ</string>
     <string name="pair_rename_label">tɔgɔ</string>
     <string name="pair_retire_title">kopila yen sorɔ</string>

--- a/app/src/main/res/values-bm/strings.xml
+++ b/app/src/main/res/values-bm/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">fanga kelen na</string>
     <string name="pair_cycles">siklo</string>
     <string name="pair_charge_watched">a filɛra</string>
+    <string name="pair_vs_new">ni kura ye</string>
     <string name="pair_cycle_number">siklo %1$d</string>
     <string name="pair_rename_title">kopila tɔgɔ sɛbɛ</string>
     <string name="pair_rename_label">tɔgɔ</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">প্রতি চার্জে</string>
     <string name="pair_cycles">চক্র</string>
     <string name="pair_charge_watched">পর্যবেক্ষিত</string>
+    <string name="pair_vs_new">নতুনের তুলনায়</string>
     <string name="pair_cycle_number">চক্র %1$d</string>
     <string name="pair_rename_title">জোড়ার নাম পরিবর্তন করুন</string>
     <string name="pair_rename_label">নাম</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">প্রতি ঘন্টায়</string>
     <string name="pair_bought">ক্রয় করা হয়েছে</string>
     <string name="pair_daily_hours_14">দৈনিক ঘন্টা (১৪ দিন)</string>
+    <string name="pair_charge_cycles">চার্জ চক্র</string>
+    <string name="pair_per_charge">প্রতি চার্জে</string>
+    <string name="pair_cycles">চক্র</string>
+    <string name="pair_charge_watched">পর্যবেক্ষিত</string>
+    <string name="pair_cycle_number">চক্র %1$d</string>
     <string name="pair_rename_title">জোড়ার নাম পরিবর্তন করুন</string>
     <string name="pair_rename_label">নাম</string>
     <string name="pair_retire_title">এই জোড়া অবসর নিন</string>

--- a/app/src/main/res/values-bo/strings.xml
+++ b/app/src/main/res/values-bo/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ཆུ་ཙམ་རེ་</string>
     <string name="pair_bought">ཕུལ་</string>
     <string name="pair_daily_hours_14">ཉིན་རེར་དུས་ཆུ་ཙམ་ (ཉིན་མོ་བཅུ་བཞི་)</string>
+    <string name="pair_charge_cycles">གློག་བསྐྱོན་སྐོར་རིམ།</string>
+    <string name="pair_per_charge">གློག་བསྐྱོན་རེར།</string>
+    <string name="pair_cycles">སྐོར་རིམ།</string>
+    <string name="pair_charge_watched">ལྟ་ཞིབ་བྱས་པ།</string>
+    <string name="pair_cycle_number">སྐོར་རིམ་ %1$d</string>
     <string name="pair_rename_title">སོགས་ཅིག་མིང་བསྒྱུར་</string>
     <string name="pair_rename_label">མིང་</string>
     <string name="pair_retire_title">སོགས་ཅིག་སྐུར་</string>

--- a/app/src/main/res/values-bo/strings.xml
+++ b/app/src/main/res/values-bo/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">གློག་བསྐྱོན་རེར།</string>
     <string name="pair_cycles">སྐོར་རིམ།</string>
     <string name="pair_charge_watched">ལྟ་ཞིབ་བྱས་པ།</string>
+    <string name="pair_vs_new">གསར་པའི་སྐབས་དང་བསྡུར་ན།</string>
     <string name="pair_cycle_number">སྐོར་རིམ་ %1$d</string>
     <string name="pair_rename_title">སོགས་ཅིག་མིང་བསྒྱུར་</string>
     <string name="pair_rename_label">མིང་</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">dre eurvezh</string>
     <string name="pair_bought">prenet</string>
     <string name="pair_daily_hours_14">eurvezhioù dre deiz (14 devezhioù)</string>
+    <string name="pair_charge_cycles">kelc’hiadoù kargañ</string>
+    <string name="pair_per_charge">dre gargad</string>
+    <string name="pair_cycles">kelc’hiadoù</string>
+    <string name="pair_charge_watched">evezhiet</string>
+    <string name="pair_cycle_number">kelc’hiad %1$d</string>
     <string name="pair_rename_title">adenvel ur parol</string>
     <string name="pair_rename_label">anv</string>
     <string name="pair_retire_title">digemer ar parol-mañ</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">dre gargad</string>
     <string name="pair_cycles">kelc’hiadoù</string>
     <string name="pair_charge_watched">evezhiet</string>
+    <string name="pair_vs_new">e-keñver nevez</string>
     <string name="pair_cycle_number">kelc’hiad %1$d</string>
     <string name="pair_rename_title">adenvel ur parol</string>
     <string name="pair_rename_label">anv</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -96,6 +96,11 @@
     <string name="pair_per_hour">per hora</string>
     <string name="pair_bought">comprat</string>
     <string name="pair_daily_hours_14">hores diàries (14 dies)</string>
+    <string name="pair_charge_cycles">cicles de càrrega</string>
+    <string name="pair_per_charge">per càrrega</string>
+    <string name="pair_cycles">cicles</string>
+    <string name="pair_charge_watched">observat</string>
+    <string name="pair_cycle_number">cicle %1$d</string>
     <string name="pair_rename_title">canviar nom del parell</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">jubilar aquest parell</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -100,6 +100,7 @@
     <string name="pair_per_charge">per càrrega</string>
     <string name="pair_cycles">cicles</string>
     <string name="pair_charge_watched">observat</string>
+    <string name="pair_vs_new">respecte a nous</string>
     <string name="pair_cycle_number">cicle %1$d</string>
     <string name="pair_rename_title">canviar nom del parell</string>
     <string name="pair_rename_label">nom</string>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">цхьана зарядна</string>
     <string name="pair_cycles">циклаш</string>
     <string name="pair_charge_watched">хьовсина</string>
+    <string name="pair_vs_new">керлачарца юсттина</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">пара чӏаргӏалча</string>
     <string name="pair_rename_label">йиза</string>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">соьатан яьлча</string>
     <string name="pair_bought">кӏанӏах</string>
     <string name="pair_daily_hours_14">сак соьатаяр (14 ДӀа)</string>
+    <string name="pair_charge_cycles">зарядан циклаш</string>
+    <string name="pair_per_charge">цхьана зарядна</string>
+    <string name="pair_cycles">циклаш</string>
+    <string name="pair_charge_watched">хьовсина</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">пара чӏаргӏалча</string>
     <string name="pair_rename_label">йиза</string>
     <string name="pair_retire_title">мындара пара дӏаяьллча</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">za hodinu</string>
     <string name="pair_bought">koupeno</string>
     <string name="pair_daily_hours_14">hodiny denně (14 dní)</string>
+    <string name="pair_charge_cycles">nabíjecí cykly</string>
+    <string name="pair_per_charge">na nabití</string>
+    <string name="pair_cycles">cykly</string>
+    <string name="pair_charge_watched">sledováno</string>
+    <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">přejmenovat pár</string>
     <string name="pair_rename_label">název</string>
     <string name="pair_retire_title">vyřadit tento pár</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">na nabití</string>
     <string name="pair_cycles">cykly</string>
     <string name="pair_charge_watched">sledováno</string>
+    <string name="pair_vs_new">oproti novým</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">přejmenovat pár</string>
     <string name="pair_rename_label">název</string>

--- a/app/src/main/res/values-cv/strings.xml
+++ b/app/src/main/res/values-cv/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">сехетре</string>
     <string name="pair_bought">туяннӑ</string>
     <string name="pair_daily_hours_14">кулленхи сехетсем (14 кун)</string>
+    <string name="pair_charge_cycles">заряд циклӗсем</string>
+    <string name="pair_per_charge">пӗр заряда</string>
+    <string name="pair_cycles">циклсем</string>
+    <string name="pair_charge_watched">сӑнанӑ</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">мӑшӑр ятне улӑштар</string>
     <string name="pair_rename_label">ят</string>
     <string name="pair_retire_title">ҫак мӑшӑра усӑран кӑлар</string>

--- a/app/src/main/res/values-cv/strings.xml
+++ b/app/src/main/res/values-cv/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">пӗр заряда</string>
     <string name="pair_cycles">циклсем</string>
     <string name="pair_charge_watched">сӑнанӑ</string>
+    <string name="pair_vs_new">ҫӗннипе танлаштарсан</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">мӑшӑр ятне улӑштар</string>
     <string name="pair_rename_label">ят</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">y gwefriad</string>
     <string name="pair_cycles">cylchoedd</string>
     <string name="pair_charge_watched">wedi’i wylio</string>
+    <string name="pair_vs_new">o’i gymharu â newydd</string>
     <string name="pair_cycle_number">cylch %1$d</string>
     <string name="pair_rename_title">ailenwi pâr</string>
     <string name="pair_rename_label">enw</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">yr awr</string>
     <string name="pair_bought">prynu</string>
     <string name="pair_daily_hours_14">oriau bob dydd (14 diwrnod)</string>
+    <string name="pair_charge_cycles">cylchoedd gwefru</string>
+    <string name="pair_per_charge">y gwefriad</string>
+    <string name="pair_cycles">cylchoedd</string>
+    <string name="pair_charge_watched">wedi’i wylio</string>
+    <string name="pair_cycle_number">cylch %1$d</string>
     <string name="pair_rename_title">ailenwi pâr</string>
     <string name="pair_rename_label">enw</string>
     <string name="pair_retire_title">tynnu’r pâr hwn ymaith</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">pr. time</string>
     <string name="pair_bought">købt</string>
     <string name="pair_daily_hours_14">timer pr. dag (14 dage)</string>
+    <string name="pair_charge_cycles">opladningscyklusser</string>
+    <string name="pair_per_charge">pr. opladning</string>
+    <string name="pair_cycles">cyklusser</string>
+    <string name="pair_charge_watched">observeret</string>
+    <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">omdøb par</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">udfas dette par</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">pr. opladning</string>
     <string name="pair_cycles">cyklusser</string>
     <string name="pair_charge_watched">observeret</string>
+    <string name="pair_vs_new">mod da de var nye</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">omdøb par</string>
     <string name="pair_rename_label">navn</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_per_charge">pro ladung</string>
     <string name="pair_cycles">zyklen</string>
     <string name="pair_charge_watched">beobachtet</string>
+    <string name="pair_vs_new">gegenüber neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">Paar umbenennen</string>
     <string name="pair_rename_label">Name</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -100,6 +100,11 @@
     <string name="pair_per_hour">pro Stunde</string>
     <string name="pair_bought">gekauft</string>
     <string name="pair_daily_hours_14">Stunden pro Tag (14 Tage)</string>
+    <string name="pair_charge_cycles">ladezyklen</string>
+    <string name="pair_per_charge">pro ladung</string>
+    <string name="pair_cycles">zyklen</string>
+    <string name="pair_charge_watched">beobachtet</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">Paar umbenennen</string>
     <string name="pair_rename_label">Name</string>
     <string name="pair_retire_title">dieses Paar ausmustern</string>

--- a/app/src/main/res/values-dz/strings.xml
+++ b/app/src/main/res/values-dz/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">གློག་བཙུགས་རེར།</string>
     <string name="pair_cycles">སྐོར་རིམ།</string>
     <string name="pair_charge_watched">བལྟ་ཡོདཔ།</string>
+    <string name="pair_vs_new">གསརཔ་དང་བསྡུར་བ།</string>
     <string name="pair_cycle_number">སྐོར་རིམ་ %1$d</string>
     <string name="pair_rename_title">ཕོ་ཉའི་མིང་གི་བསྒྲུབ་པ།</string>
     <string name="pair_rename_label">མིང་།</string>

--- a/app/src/main/res/values-dz/strings.xml
+++ b/app/src/main/res/values-dz/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ཆུ་ཙོ་ཡིས་རེ།</string>
     <string name="pair_bought">ཁོར་ལེན་ཞིང་།</string>
     <string name="pair_daily_hours_14">ཉིན་རེའི་ཆུ་ཙོ་ (༧དགུ་བཞི་ ཉིན་)</string>
+    <string name="pair_charge_cycles">གློག་བཙུགས་སྐོར་རིམ།</string>
+    <string name="pair_per_charge">གློག་བཙུགས་རེར།</string>
+    <string name="pair_cycles">སྐོར་རིམ།</string>
+    <string name="pair_charge_watched">བལྟ་ཡོདཔ།</string>
+    <string name="pair_cycle_number">སྐོར་རིམ་ %1$d</string>
     <string name="pair_rename_title">ཕོ་ཉའི་མིང་གི་བསྒྲུབ་པ།</string>
     <string name="pair_rename_label">མིང་།</string>
     <string name="pair_retire_title">འདི་ཕོ་ཉ་རིས་བསྐུར་ཞུ།</string>

--- a/app/src/main/res/values-ee/strings.xml
+++ b/app/src/main/res/values-ee/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">gaƒoƒo ƒe</string>
     <string name="pair_bought">ƒu</string>
     <string name="pair_daily_hours_14">gaƒoƒo ŋkeke ƒe (ŋkeke 14)</string>
+    <string name="pair_charge_cycles">ŋusẽdodo ƒe tɔtrɔwo</string>
+    <string name="pair_per_charge">ŋusẽdodo ɖeka</string>
+    <string name="pair_cycles">tɔtrɔwo</string>
+    <string name="pair_charge_watched">wolé ŋku ɖe eŋu</string>
+    <string name="pair_cycle_number">tɔtrɔ %1$d</string>
     <string name="pair_rename_title">ɖokuɖo ŋkɔ tsɔ</string>
     <string name="pair_rename_label">ŋkɔ</string>
     <string name="pair_retire_title">ɖokuɖo sia ɖa</string>

--- a/app/src/main/res/values-ee/strings.xml
+++ b/app/src/main/res/values-ee/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ŋusẽdodo ɖeka</string>
     <string name="pair_cycles">tɔtrɔwo</string>
     <string name="pair_charge_watched">wolé ŋku ɖe eŋu</string>
+    <string name="pair_vs_new">tsɔ sɔ kple yeye</string>
     <string name="pair_cycle_number">tɔtrɔ %1$d</string>
     <string name="pair_rename_title">ɖokuɖo ŋkɔ tsɔ</string>
     <string name="pair_rename_label">ŋkɔ</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">ανά ώρα</string>
     <string name="pair_bought">αγοράστηκε</string>
     <string name="pair_daily_hours_14">ώρες ανά ημέρα (14 ημέρες)</string>
+    <string name="pair_charge_cycles">κύκλοι φόρτισης</string>
+    <string name="pair_per_charge">ανά φόρτιση</string>
+    <string name="pair_cycles">κύκλοι</string>
+    <string name="pair_charge_watched">παρακολουθήθηκε</string>
+    <string name="pair_cycle_number">κύκλος %1$d</string>
     <string name="pair_rename_title">μετονομασία ζευγαριού</string>
     <string name="pair_rename_label">όνομα</string>
     <string name="pair_retire_title">απόσυρση αυτού του ζευγαριού</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">ανά φόρτιση</string>
     <string name="pair_cycles">κύκλοι</string>
     <string name="pair_charge_watched">παρακολουθήθηκε</string>
+    <string name="pair_vs_new">έναντι καινούριων</string>
     <string name="pair_cycle_number">κύκλος %1$d</string>
     <string name="pair_rename_title">μετονομασία ζευγαριού</string>
     <string name="pair_rename_label">όνομα</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">po horo</string>
     <string name="pair_bought">aĉetita</string>
     <string name="pair_daily_hours_14">horoj po tago (14 tagoj)</string>
+    <string name="pair_charge_cycles">ŝargociklaj</string>
+    <string name="pair_per_charge">po ŝargo</string>
+    <string name="pair_cycles">cikloj</string>
+    <string name="pair_charge_watched">observita</string>
+    <string name="pair_cycle_number">ciklo %1$d</string>
     <string name="pair_rename_title">renomi paron</string>
     <string name="pair_rename_label">nomo</string>
     <string name="pair_retire_title">pensigu ĉi tiun paron</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">po ŝargo</string>
     <string name="pair_cycles">cikloj</string>
     <string name="pair_charge_watched">observita</string>
+    <string name="pair_vs_new">kompare al nova</string>
     <string name="pair_cycle_number">ciklo %1$d</string>
     <string name="pair_rename_title">renomi paron</string>
     <string name="pair_rename_label">nomo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">por hora</string>
     <string name="pair_bought">comprado</string>
     <string name="pair_daily_hours_14">horas diarias (14 días)</string>
+    <string name="pair_charge_cycles">ciclos de carga</string>
+    <string name="pair_per_charge">por carga</string>
+    <string name="pair_cycles">ciclos</string>
+    <string name="pair_charge_watched">observado</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">cambiar nombre del par</string>
     <string name="pair_rename_label">nombre</string>
     <string name="pair_retire_title">retirar este par</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">por carga</string>
     <string name="pair_cycles">ciclos</string>
     <string name="pair_charge_watched">observado</string>
+    <string name="pair_vs_new">respecto a nuevos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">cambiar nombre del par</string>
     <string name="pair_rename_label">nombre</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">laadimise kohta</string>
     <string name="pair_cycles">tsüklid</string>
     <string name="pair_charge_watched">jälgitud</string>
+    <string name="pair_vs_new">võrreldes uuega</string>
     <string name="pair_cycle_number">tsükkel %1$d</string>
     <string name="pair_rename_title">nimeta paar ümber</string>
     <string name="pair_rename_label">nimi</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">tunni kohta</string>
     <string name="pair_bought">ostetud</string>
     <string name="pair_daily_hours_14">tunni päevas (14 päeva)</string>
+    <string name="pair_charge_cycles">laadimistsüklid</string>
+    <string name="pair_per_charge">laadimise kohta</string>
+    <string name="pair_cycles">tsüklid</string>
+    <string name="pair_charge_watched">jälgitud</string>
+    <string name="pair_cycle_number">tsükkel %1$d</string>
     <string name="pair_rename_title">nimeta paar ümber</string>
     <string name="pair_rename_label">nimi</string>
     <string name="pair_retire_title">pensioneeri see paar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">orduko</string>
     <string name="pair_bought">erosita</string>
     <string name="pair_daily_hours_14">orduak egunero (14 eguna)</string>
+    <string name="pair_charge_cycles">karga-zikloak</string>
+    <string name="pair_per_charge">karga bakoitzeko</string>
+    <string name="pair_cycles">zikloak</string>
+    <string name="pair_charge_watched">behatuta</string>
+    <string name="pair_cycle_number">%1$d. zikloa</string>
     <string name="pair_rename_title">pareza berrizendatu</string>
     <string name="pair_rename_label">izena</string>
     <string name="pair_retire_title">pare hau jubilatu</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">karga bakoitzeko</string>
     <string name="pair_cycles">zikloak</string>
     <string name="pair_charge_watched">behatuta</string>
+    <string name="pair_vs_new">berri zirenekoaren aldean</string>
     <string name="pair_cycle_number">%1$d. zikloa</string>
     <string name="pair_rename_title">pareza berrizendatu</string>
     <string name="pair_rename_label">izena</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">در ساعت</string>
     <string name="pair_bought">خریداری شده</string>
     <string name="pair_daily_hours_14">ساعات روزانه (14 روز)</string>
+    <string name="pair_charge_cycles">چرخه‌های شارژ</string>
+    <string name="pair_per_charge">در هر شارژ</string>
+    <string name="pair_cycles">چرخه‌ها</string>
+    <string name="pair_charge_watched">رصدشده</string>
+    <string name="pair_cycle_number">چرخه %1$d</string>
     <string name="pair_rename_title">تغییر نام جفت</string>
     <string name="pair_rename_label">نام</string>
     <string name="pair_retire_title">بازنشسته کردن این جفت</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">در هر شارژ</string>
     <string name="pair_cycles">چرخه‌ها</string>
     <string name="pair_charge_watched">رصدشده</string>
+    <string name="pair_vs_new">نسبت به نو</string>
     <string name="pair_cycle_number">چرخه %1$d</string>
     <string name="pair_rename_title">تغییر نام جفت</string>
     <string name="pair_rename_label">نام</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">latausta kohti</string>
     <string name="pair_cycles">syklit</string>
     <string name="pair_charge_watched">seurattu</string>
+    <string name="pair_vs_new">uutena verrattuna</string>
     <string name="pair_cycle_number">sykli %1$d</string>
     <string name="pair_rename_title">nimeä pari uudelleen</string>
     <string name="pair_rename_label">nimi</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">tunnilta</string>
     <string name="pair_bought">ostettu</string>
     <string name="pair_daily_hours_14">tunnit päivässä (14 päivää)</string>
+    <string name="pair_charge_cycles">lataussyklit</string>
+    <string name="pair_per_charge">latausta kohti</string>
+    <string name="pair_cycles">syklit</string>
+    <string name="pair_charge_watched">seurattu</string>
+    <string name="pair_cycle_number">sykli %1$d</string>
     <string name="pair_rename_title">nimeä pari uudelleen</string>
     <string name="pair_rename_label">nimi</string>
     <string name="pair_retire_title">poista tämä pari käytöstä</string>

--- a/app/src/main/res/values-fo/strings.xml
+++ b/app/src/main/res/values-fo/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">um tíman</string>
     <string name="pair_bought">keypt</string>
     <string name="pair_daily_hours_14">daglig tímar (14 dagar)</string>
+    <string name="pair_charge_cycles">løðingarsyklusar</string>
+    <string name="pair_per_charge">pr. løðing</string>
+    <string name="pair_cycles">syklusar</string>
+    <string name="pair_charge_watched">eftirhugt</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">endurnefna pair</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">útfasa hesa pair</string>

--- a/app/src/main/res/values-fo/strings.xml
+++ b/app/src/main/res/values-fo/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">pr. løðing</string>
     <string name="pair_cycles">syklusar</string>
     <string name="pair_charge_watched">eftirhugt</string>
+    <string name="pair_vs_new">mót nýggjum</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">endurnefna pair</string>
     <string name="pair_rename_label">navn</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">par charge</string>
     <string name="pair_cycles">cycles</string>
     <string name="pair_charge_watched">observé</string>
+    <string name="pair_vs_new">par rapport au neuf</string>
     <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">renommer la paire</string>
     <string name="pair_rename_label">nom</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">de l’heure</string>
     <string name="pair_bought">achetée</string>
     <string name="pair_daily_hours_14">heures par jour (14 jours)</string>
+    <string name="pair_charge_cycles">cycles de charge</string>
+    <string name="pair_per_charge">par charge</string>
+    <string name="pair_cycles">cycles</string>
+    <string name="pair_charge_watched">observé</string>
+    <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">renommer la paire</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">retirer cette paire</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per oere</string>
     <string name="pair_bought">keapte</string>
     <string name="pair_daily_hours_14">deistige oeren (14 dagen)</string>
+    <string name="pair_charge_cycles">laadsyklussen</string>
+    <string name="pair_per_charge">de laadbeurt</string>
+    <string name="pair_cycles">syklussen</string>
+    <string name="pair_charge_watched">waarnommen</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">dit pear omneame</string>
     <string name="pair_rename_label">namme</string>
     <string name="pair_retire_title">dit pear ôfskied</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">de laadbeurt</string>
     <string name="pair_cycles">syklussen</string>
     <string name="pair_charge_watched">waarnommen</string>
+    <string name="pair_vs_new">tsjin nij oer</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">dit pear omneame</string>
     <string name="pair_rename_label">namme</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">in aghaidh an uaire</string>
     <string name="pair_bought">ceannaithe</string>
     <string name="pair_daily_hours_14">uaireanta laethúla (14 lá)</string>
+    <string name="pair_charge_cycles">timthriallta luchtaithe</string>
+    <string name="pair_per_charge">in aghaidh an luchtaithe</string>
+    <string name="pair_cycles">timthriallta</string>
+    <string name="pair_charge_watched">faoi bhreathnú</string>
+    <string name="pair_cycle_number">timthriall %1$d</string>
     <string name="pair_rename_title">athainmnigh péire</string>
     <string name="pair_rename_label">ainm</string>
     <string name="pair_retire_title">scoir an péire seo</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">in aghaidh an luchtaithe</string>
     <string name="pair_cycles">timthriallta</string>
     <string name="pair_charge_watched">faoi bhreathnú</string>
+    <string name="pair_vs_new">i gcomparáid le nua</string>
     <string name="pair_cycle_number">timthriall %1$d</string>
     <string name="pair_rename_title">athainmnigh péire</string>
     <string name="pair_rename_label">ainm</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">gach uair a thìde</string>
     <string name="pair_bought">a cheannaich</string>
     <string name="pair_daily_hours_14">uairean laitheil (14 latha)</string>
+    <string name="pair_charge_cycles">cuairtean teairrsidh</string>
+    <string name="pair_per_charge">gach teairrseadh</string>
+    <string name="pair_cycles">cuairtean</string>
+    <string name="pair_charge_watched">fo shùil</string>
+    <string name="pair_cycle_number">cuairt %1$d</string>
     <string name="pair_rename_title">ath-ainm paidhir</string>
     <string name="pair_rename_label">ainm</string>
     <string name="pair_retire_title">air falbh an paidhir seo</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">gach teairrseadh</string>
     <string name="pair_cycles">cuairtean</string>
     <string name="pair_charge_watched">fo shùil</string>
+    <string name="pair_vs_new">an coimeas ri ùr</string>
     <string name="pair_cycle_number">cuairt %1$d</string>
     <string name="pair_rename_title">ath-ainm paidhir</string>
     <string name="pair_rename_label">ainm</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">por carga</string>
     <string name="pair_cycles">ciclos</string>
     <string name="pair_charge_watched">observado</string>
+    <string name="pair_vs_new">fronte a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">por hora</string>
     <string name="pair_bought">comprado</string>
     <string name="pair_daily_hours_14">horas diarias (14 días)</string>
+    <string name="pair_charge_cycles">ciclos de carga</string>
+    <string name="pair_per_charge">por carga</string>
+    <string name="pair_cycles">ciclos</string>
+    <string name="pair_charge_watched">observado</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">xubilar este par</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">પ્રતિ કલાક</string>
     <string name="pair_bought">ખરીદ્યું</string>
     <string name="pair_daily_hours_14">દૈનિક કલાક (14 દિવસ)</string>
+    <string name="pair_charge_cycles">ચાર્જ ચક્રો</string>
+    <string name="pair_per_charge">દર ચાર્જે</string>
+    <string name="pair_cycles">ચક્રો</string>
+    <string name="pair_charge_watched">અવલોકન કરેલ</string>
+    <string name="pair_cycle_number">ચક્ર %1$d</string>
     <string name="pair_rename_title">જોડીનું નામ બદલો</string>
     <string name="pair_rename_label">નામ</string>
     <string name="pair_retire_title">આ જોડીને સેવાનિવૃત્ત કરો</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">દર ચાર્જે</string>
     <string name="pair_cycles">ચક્રો</string>
     <string name="pair_charge_watched">અવલોકન કરેલ</string>
+    <string name="pair_vs_new">નવા હતા ત્યારની સરખામણીએ</string>
     <string name="pair_cycle_number">ચક્ર %1$d</string>
     <string name="pair_rename_title">જોડીનું નામ બદલો</string>
     <string name="pair_rename_label">નામ</string>

--- a/app/src/main/res/values-gv/strings.xml
+++ b/app/src/main/res/values-gv/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">son oor</string>
     <string name="pair_bought">cheannit</string>
     <string name="pair_daily_hours_14">oor jiu (14 laa)</string>
+    <string name="pair_charge_cycles">cruinnaghyn chargal</string>
+    <string name="pair_per_charge">y chargey</string>
+    <string name="pair_cycles">cruinnaghyn</string>
+    <string name="pair_charge_watched">jeeaghit</string>
+    <string name="pair_cycle_number">cruinnagh %1$d</string>
     <string name="pair_rename_title">cur ennym noa paart</string>
     <string name="pair_rename_label">ennym</string>
     <string name="pair_retire_title">shoh kiart er paart shoh</string>

--- a/app/src/main/res/values-gv/strings.xml
+++ b/app/src/main/res/values-gv/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">y chargey</string>
     <string name="pair_cycles">cruinnaghyn</string>
     <string name="pair_charge_watched">jeeaghit</string>
+    <string name="pair_vs_new">noi rish noa</string>
     <string name="pair_cycle_number">cruinnagh %1$d</string>
     <string name="pair_rename_title">cur ennym noa paart</string>
     <string name="pair_rename_label">ennym</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">a awa</string>
     <string name="pair_bought">sabani</string>
     <string name="pair_daily_hours_14">awannin yau-yau (kwanaki 14)</string>
+    <string name="pair_charge_cycles">zagayen caji</string>
+    <string name="pair_per_charge">kowane caji</string>
+    <string name="pair_cycles">zagaye</string>
+    <string name="pair_charge_watched">an lura</string>
+    <string name="pair_cycle_number">zagaye %1$d</string>
     <string name="pair_rename_title">sayi suna jimla</string>
     <string name="pair_rename_label">suna</string>
     <string name="pair_retire_title">dakatar jimlar nan</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kowane caji</string>
     <string name="pair_cycles">zagaye</string>
     <string name="pair_charge_watched">an lura</string>
+    <string name="pair_vs_new">idan aka kwatanta da sabo</string>
     <string name="pair_cycle_number">zagaye %1$d</string>
     <string name="pair_rename_title">sayi suna jimla</string>
     <string name="pair_rename_label">suna</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -100,6 +100,11 @@
     <string name="pair_per_hour">प्रति घंटा</string>
     <string name="pair_bought">खरीदी</string>
     <string name="pair_daily_hours_14">रोज़ाना घंटे (14 दिन)</string>
+    <string name="pair_charge_cycles">चार्ज चक्र</string>
+    <string name="pair_per_charge">प्रति चार्ज</string>
+    <string name="pair_cycles">चक्र</string>
+    <string name="pair_charge_watched">देखा गया</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ी का नाम बदलें</string>
     <string name="pair_rename_label">नाम</string>
     <string name="pair_retire_title">इस जोड़ी को रिटायर करें</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_per_charge">प्रति चार्ज</string>
     <string name="pair_cycles">चक्र</string>
     <string name="pair_charge_watched">देखा गया</string>
+    <string name="pair_vs_new">नए की तुलना में</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोड़ी का नाम बदलें</string>
     <string name="pair_rename_label">नाम</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">po punjenju</string>
     <string name="pair_cycles">ciklusi</string>
     <string name="pair_charge_watched">promatrano</string>
+    <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenujem par</string>
     <string name="pair_rename_label">ime</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">po satu</string>
     <string name="pair_bought">kupljeno</string>
     <string name="pair_daily_hours_14">sati dnevno (14 dana)</string>
+    <string name="pair_charge_cycles">ciklusi punjenja</string>
+    <string name="pair_per_charge">po punjenju</string>
+    <string name="pair_cycles">ciklusi</string>
+    <string name="pair_charge_watched">promatrano</string>
+    <string name="pair_cycle_number">ciklus %1$d</string>
     <string name="pair_rename_title">preimenujem par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">povuci ovaj par</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">óránként</string>
     <string name="pair_bought">vásárolva</string>
     <string name="pair_daily_hours_14">napi órák (14 nap)</string>
+    <string name="pair_charge_cycles">töltési ciklusok</string>
+    <string name="pair_per_charge">töltésenként</string>
+    <string name="pair_cycles">ciklusok</string>
+    <string name="pair_charge_watched">megfigyelve</string>
+    <string name="pair_cycle_number">%1$d. ciklus</string>
     <string name="pair_rename_title">pár átnevezése</string>
     <string name="pair_rename_label">név</string>
     <string name="pair_retire_title">pár kivonása</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">töltésenként</string>
     <string name="pair_cycles">ciklusok</string>
     <string name="pair_charge_watched">megfigyelve</string>
+    <string name="pair_vs_new">az újhoz képest</string>
     <string name="pair_cycle_number">%1$d. ciklus</string>
     <string name="pair_rename_title">pár átnevezése</string>
     <string name="pair_rename_label">név</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">մեկ լիցքով</string>
     <string name="pair_cycles">ցիկլեր</string>
     <string name="pair_charge_watched">դիտարկված</string>
+    <string name="pair_vs_new">նորի համեմատ</string>
     <string name="pair_cycle_number">ցիկլ %1$d</string>
     <string name="pair_rename_title">զույգը վերանվանել</string>
     <string name="pair_rename_label">անուն</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ժամի համար</string>
     <string name="pair_bought">գնված</string>
     <string name="pair_daily_hours_14">ամենօրյա ժամեր (14 օր)</string>
+    <string name="pair_charge_cycles">լիցքավորման ցիկլեր</string>
+    <string name="pair_per_charge">մեկ լիցքով</string>
+    <string name="pair_cycles">ցիկլեր</string>
+    <string name="pair_charge_watched">դիտարկված</string>
+    <string name="pair_cycle_number">ցիկլ %1$d</string>
     <string name="pair_rename_title">զույգը վերանվանել</string>
     <string name="pair_rename_label">անուն</string>
     <string name="pair_retire_title">այս զույգը տեղադրել</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per hora</string>
     <string name="pair_bought">comparate</string>
     <string name="pair_daily_hours_14">horas quotidiane (14 dies)</string>
+    <string name="pair_charge_cycles">cyclos de carga</string>
+    <string name="pair_per_charge">per carga</string>
+    <string name="pair_cycles">cyclos</string>
+    <string name="pair_charge_watched">observate</string>
+    <string name="pair_cycle_number">cyclo %1$d</string>
     <string name="pair_rename_title">renominar parea</string>
     <string name="pair_rename_label">nomine</string>
     <string name="pair_retire_title">retira iste parea</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per carga</string>
     <string name="pair_cycles">cyclos</string>
     <string name="pair_charge_watched">observate</string>
+    <string name="pair_vs_new">comparate a nove</string>
     <string name="pair_cycle_number">cyclo %1$d</string>
     <string name="pair_rename_title">renominar parea</string>
     <string name="pair_rename_label">nomine</string>

--- a/app/src/main/res/values-ie/strings.xml
+++ b/app/src/main/res/values-ie/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per charga</string>
     <string name="pair_cycles">cicles</string>
     <string name="pair_charge_watched">observat</string>
+    <string name="pair_vs_new">comparat a nov</string>
     <string name="pair_cycle_number">cicle %1$d</string>
     <string name="pair_rename_title">renoma par</string>
     <string name="pair_rename_label">nom</string>

--- a/app/src/main/res/values-ie/strings.xml
+++ b/app/src/main/res/values-ie/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per hor</string>
     <string name="pair_bought">achatat</string>
     <string name="pair_daily_hours_14">quotidian hor (14 dies)</string>
+    <string name="pair_charge_cycles">cicles de charga</string>
+    <string name="pair_per_charge">per charga</string>
+    <string name="pair_cycles">cicles</string>
+    <string name="pair_charge_watched">observat</string>
+    <string name="pair_cycle_number">cicle %1$d</string>
     <string name="pair_rename_title">renoma par</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">retire ti par</string>

--- a/app/src/main/res/values-ig/strings.xml
+++ b/app/src/main/res/values-ig/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa awa</string>
     <string name="pair_bought">zụrụ</string>
     <string name="pair_daily_hours_14">ọrọ kwa ụbọchị (ụbọchị 14)</string>
+    <string name="pair_charge_cycles">okirikiri ijupụta</string>
+    <string name="pair_per_charge">kwa ijupụta</string>
+    <string name="pair_cycles">okirikiri</string>
+    <string name="pair_charge_watched">elere anya</string>
+    <string name="pair_cycle_number">okirikiri %1$d</string>
     <string name="pair_rename_title">gbanwee aha peeà</string>
     <string name="pair_rename_label">aha</string>
     <string name="pair_retire_title">gbado peeà a</string>

--- a/app/src/main/res/values-ig/strings.xml
+++ b/app/src/main/res/values-ig/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa ijupụta</string>
     <string name="pair_cycles">okirikiri</string>
     <string name="pair_charge_watched">elere anya</string>
+    <string name="pair_vs_new">ma e jiri ya tụnyere ọhụrụ</string>
     <string name="pair_cycle_number">okirikiri %1$d</string>
     <string name="pair_rename_title">gbanwee aha peeà</string>
     <string name="pair_rename_label">aha</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">per pengisian</string>
     <string name="pair_cycles">siklus</string>
     <string name="pair_charge_watched">teramati</string>
+    <string name="pair_vs_new">dibanding saat baru</string>
     <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti nama pasangan</string>
     <string name="pair_rename_label">nama</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">per jam</string>
     <string name="pair_bought">dibeli</string>
     <string name="pair_daily_hours_14">jam harian (14 hari)</string>
+    <string name="pair_charge_cycles">siklus pengisian</string>
+    <string name="pair_per_charge">per pengisian</string>
+    <string name="pair_cycles">siklus</string>
+    <string name="pair_charge_watched">teramati</string>
+    <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti nama pasangan</string>
     <string name="pair_rename_label">nama</string>
     <string name="pair_retire_title">pensiunkan pasangan ini</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">á klukkustund</string>
     <string name="pair_bought">keypt</string>
     <string name="pair_daily_hours_14">daglegar stundir (14 dagar)</string>
+    <string name="pair_charge_cycles">hleðslulotur</string>
+    <string name="pair_per_charge">á hleðslu</string>
+    <string name="pair_cycles">lotur</string>
+    <string name="pair_charge_watched">fylgst með</string>
+    <string name="pair_cycle_number">lota %1$d</string>
     <string name="pair_rename_title">endurnefna par</string>
     <string name="pair_rename_label">nafn</string>
     <string name="pair_retire_title">starfslok fyrir þetta par</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">á hleðslu</string>
     <string name="pair_cycles">lotur</string>
     <string name="pair_charge_watched">fylgst með</string>
+    <string name="pair_vs_new">miðað við ný</string>
     <string name="pair_cycle_number">lota %1$d</string>
     <string name="pair_rename_title">endurnefna par</string>
     <string name="pair_rename_label">nafn</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">all’ora</string>
     <string name="pair_bought">acquistate</string>
     <string name="pair_daily_hours_14">ore al giorno (14 giorni)</string>
+    <string name="pair_charge_cycles">cicli di carica</string>
+    <string name="pair_per_charge">per carica</string>
+    <string name="pair_cycles">cicli</string>
+    <string name="pair_charge_watched">osservato</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">rinomina paio</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">ritira questo paio</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">per carica</string>
     <string name="pair_cycles">cicli</string>
     <string name="pair_charge_watched">osservato</string>
+    <string name="pair_vs_new">rispetto a nuove</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">rinomina paio</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -99,6 +99,11 @@
     <string name="pair_per_hour">לשעה</string>
     <string name="pair_bought">נקנה</string>
     <string name="pair_daily_hours_14">שעות יומיות (14 ימים)</string>
+    <string name="pair_charge_cycles">מחזורי טעינה</string>
+    <string name="pair_per_charge">לכל טעינה</string>
+    <string name="pair_cycles">מחזורים</string>
+    <string name="pair_charge_watched">נמדד</string>
+    <string name="pair_cycle_number">מחזור %1$d</string>
     <string name="pair_rename_title">שינוי שם הזוג</string>
     <string name="pair_rename_label">שם</string>
     <string name="pair_retire_title">להוציא את הזוג הזה לגמלאות</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_per_charge">לכל טעינה</string>
     <string name="pair_cycles">מחזורים</string>
     <string name="pair_charge_watched">נמדד</string>
+    <string name="pair_vs_new">לעומת חדשות</string>
     <string name="pair_cycle_number">מחזור %1$d</string>
     <string name="pair_rename_title">שינוי שם הזוג</string>
     <string name="pair_rename_label">שם</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_per_charge">1回の充電あたり</string>
     <string name="pair_cycles">サイクル</string>
     <string name="pair_charge_watched">観測時間</string>
+    <string name="pair_vs_new">新品時との比</string>
     <string name="pair_cycle_number">サイクル %1$d</string>
     <string name="pair_rename_title">ペアの名前を変更</string>
     <string name="pair_rename_label">名前</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -100,6 +100,11 @@
     <string name="pair_per_hour">1時間あたり</string>
     <string name="pair_bought">購入日</string>
     <string name="pair_daily_hours_14">1日あたりの時間（14日間）</string>
+    <string name="pair_charge_cycles">充電サイクル</string>
+    <string name="pair_per_charge">1回の充電あたり</string>
+    <string name="pair_cycles">サイクル</string>
+    <string name="pair_charge_watched">観測時間</string>
+    <string name="pair_cycle_number">サイクル %1$d</string>
     <string name="pair_rename_title">ペアの名前を変更</string>
     <string name="pair_rename_label">名前</string>
     <string name="pair_retire_title">このペアを引退させる</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per jam</string>
     <string name="pair_bought">tuku</string>
     <string name="pair_daily_hours_14">jam saben dina (14 hari)</string>
+    <string name="pair_charge_cycles">siklus ngisi daya</string>
+    <string name="pair_per_charge">saben ngisi daya</string>
+    <string name="pair_cycles">siklus</string>
+    <string name="pair_charge_watched">diamati</string>
+    <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti jeneng rong</string>
     <string name="pair_rename_label">jeneng</string>
     <string name="pair_retire_title">tarik rong iki</string>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">saben ngisi daya</string>
     <string name="pair_cycles">siklus</string>
     <string name="pair_charge_watched">diamati</string>
+    <string name="pair_vs_new">dibandhingake anyar</string>
     <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti jeneng rong</string>
     <string name="pair_rename_label">jeneng</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">საათზე</string>
     <string name="pair_bought">ნაყიდი</string>
     <string name="pair_daily_hours_14">დღიური საათები (14 დღე)</string>
+    <string name="pair_charge_cycles">დატენვის ციკლები</string>
+    <string name="pair_per_charge">ერთ დატენვაზე</string>
+    <string name="pair_cycles">ციკლები</string>
+    <string name="pair_charge_watched">დაკვირვებული</string>
+    <string name="pair_cycle_number">ციკლი %1$d</string>
     <string name="pair_rename_title">წყვილის სახელის გადარქმევა</string>
     <string name="pair_rename_label">სახელი</string>
     <string name="pair_retire_title">ამ წყვილის გამოყენების გარეთ</string>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ერთ დატენვაზე</string>
     <string name="pair_cycles">ციკლები</string>
     <string name="pair_charge_watched">დაკვირვებული</string>
+    <string name="pair_vs_new">ახალთან შედარებით</string>
     <string name="pair_cycle_number">ციკლი %1$d</string>
     <string name="pair_rename_title">წყვილის სახელის გადარქმევა</string>
     <string name="pair_rename_label">სახელი</string>

--- a/app/src/main/res/values-ki/strings.xml
+++ b/app/src/main/res/values-ki/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">o mahoya mā ho</string>
     <string name="pair_bought">rĩndĩ</string>
     <string name="pair_daily_hours_14">mahoya ma mũthenya (matukũ 14)</string>
+    <string name="pair_charge_cycles">mithiũrũrũko ya hinya</string>
+    <string name="pair_per_charge">kwa hinya ũmwe</string>
+    <string name="pair_cycles">mithiũrũrũko</string>
+    <string name="pair_charge_watched">kũrorwo</string>
+    <string name="pair_cycle_number">mũthiũrũrũko %1$d</string>
     <string name="pair_rename_title">rekaania mahoya</string>
     <string name="pair_rename_label">ĩkwa</string>
     <string name="pair_retire_title">kwenyithia mahoya aya</string>

--- a/app/src/main/res/values-ki/strings.xml
+++ b/app/src/main/res/values-ki/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa hinya ũmwe</string>
     <string name="pair_cycles">mithiũrũrũko</string>
     <string name="pair_charge_watched">kũrorwo</string>
+    <string name="pair_vs_new">kũringithania na njerũ</string>
     <string name="pair_cycle_number">mũthiũrũrũko %1$d</string>
     <string name="pair_rename_title">rekaania mahoya</string>
     <string name="pair_rename_label">ĩkwa</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">сағатына</string>
     <string name="pair_bought">сатып алынған</string>
     <string name="pair_daily_hours_14">күндік сағаттар (14 күн)</string>
+    <string name="pair_charge_cycles">зарядтау циклдері</string>
+    <string name="pair_per_charge">бір зарядқа</string>
+    <string name="pair_cycles">циклдер</string>
+    <string name="pair_charge_watched">бақыланған</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жұпты қайта атау</string>
     <string name="pair_rename_label">аты</string>
     <string name="pair_retire_title">бұл жұпты пенсиялық</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">бір зарядқа</string>
     <string name="pair_cycles">циклдер</string>
     <string name="pair_charge_watched">бақыланған</string>
+    <string name="pair_vs_new">жаңа кезімен салыстырғанда</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жұпты қайта атау</string>
     <string name="pair_rename_label">аты</string>

--- a/app/src/main/res/values-kl/strings.xml
+++ b/app/src/main/res/values-kl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">tunivissamut</string>
     <string name="pair_cycles">kaajallattut</string>
     <string name="pair_charge_watched">nakkutigineqartoq</string>
+    <string name="pair_vs_new">nutaanerani naleqqiullugu</string>
     <string name="pair_cycle_number">kaajallanneq %1$d</string>
     <string name="pair_rename_title">allagua ataanigaleruk</string>
     <string name="pair_rename_label">ataa</string>

--- a/app/src/main/res/values-kl/strings.xml
+++ b/app/src/main/res/values-kl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">tamaasa sapaaq</string>
     <string name="pair_bought">pilerpok</string>
     <string name="pair_daily_hours_14">ulloqatigiit tamaasa (14 ulloq)</string>
+    <string name="pair_charge_cycles">tunivissat kaajallattut</string>
+    <string name="pair_per_charge">tunivissamut</string>
+    <string name="pair_cycles">kaajallattut</string>
+    <string name="pair_charge_watched">nakkutigineqartoq</string>
+    <string name="pair_cycle_number">kaajallanneq %1$d</string>
     <string name="pair_rename_title">allagua ataanigaleruk</string>
     <string name="pair_rename_label">ataa</string>
     <string name="pair_retire_title">allagua ikinngussallaleruk</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ក្នុងមួយម៉ោង</string>
     <string name="pair_bought">ទិញ</string>
     <string name="pair_daily_hours_14">ម៉ោងប្រចាំថ្ងៃ (14 ថ្ងៃ)</string>
+    <string name="pair_charge_cycles">វដ្តសាក</string>
+    <string name="pair_per_charge">ក្នុងមួយការសាក</string>
+    <string name="pair_cycles">វដ្ត</string>
+    <string name="pair_charge_watched">បានសង្កេត</string>
+    <string name="pair_cycle_number">វដ្ត %1$d</string>
     <string name="pair_rename_title">ប្តូរឈ្មោះឯកសារ</string>
     <string name="pair_rename_label">ឈ្មោះ</string>
     <string name="pair_retire_title">ដកចេញឯកសារនេះ</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ក្នុងមួយការសាក</string>
     <string name="pair_cycles">វដ្ត</string>
     <string name="pair_charge_watched">បានសង្កេត</string>
+    <string name="pair_vs_new">ធៀបនឹងពេលថ្មី</string>
     <string name="pair_cycle_number">វដ្ត %1$d</string>
     <string name="pair_rename_title">ប្តូរឈ្មោះឯកសារ</string>
     <string name="pair_rename_label">ឈ្មោះ</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ಗಂಟೆಗೆ</string>
     <string name="pair_bought">ಖರೀದಿ ಮಾಡಿದರು</string>
     <string name="pair_daily_hours_14">ದೈನಿಕ ಗಂಟೆ (14 ದಿನ)</string>
+    <string name="pair_charge_cycles">ಚಾರ್ಜ್ ಚಕ್ರಗಳು</string>
+    <string name="pair_per_charge">ಪ್ರತಿ ಚಾರ್ಜ್‌ಗೆ</string>
+    <string name="pair_cycles">ಚಕ್ರಗಳು</string>
+    <string name="pair_charge_watched">ಗಮನಿಸಲಾಗಿದೆ</string>
+    <string name="pair_cycle_number">ಚಕ್ರ %1$d</string>
     <string name="pair_rename_title">ಜೋಡಿ ಪುನರನಾಮಿತ</string>
     <string name="pair_rename_label">ಹೆಸರು</string>
     <string name="pair_retire_title">ಈ ಜೋಡಿ ನಿವೃತ್ತ</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ಪ್ರತಿ ಚಾರ್ಜ್‌ಗೆ</string>
     <string name="pair_cycles">ಚಕ್ರಗಳು</string>
     <string name="pair_charge_watched">ಗಮನಿಸಲಾಗಿದೆ</string>
+    <string name="pair_vs_new">ಹೊಸದಿದ್ದಾಗಿಗೆ ಹೋಲಿಸಿದರೆ</string>
     <string name="pair_cycle_number">ಚಕ್ರ %1$d</string>
     <string name="pair_rename_title">ಜೋಡಿ ಪುನರನಾಮಿತ</string>
     <string name="pair_rename_label">ಹೆಸರು</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">시간당</string>
     <string name="pair_bought">구매일</string>
     <string name="pair_daily_hours_14">일별 시간 (14일)</string>
+    <string name="pair_charge_cycles">충전 주기</string>
+    <string name="pair_per_charge">충전 1회당</string>
+    <string name="pair_cycles">주기</string>
+    <string name="pair_charge_watched">관측 시간</string>
+    <string name="pair_cycle_number">%1$d번째 주기</string>
     <string name="pair_rename_title">쌍 이름 바꾸기</string>
     <string name="pair_rename_label">이름</string>
     <string name="pair_retire_title">이 쌍 은퇴시키기</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">충전 1회당</string>
     <string name="pair_cycles">주기</string>
     <string name="pair_charge_watched">관측 시간</string>
+    <string name="pair_vs_new">새 제품 대비</string>
     <string name="pair_cycle_number">%1$d번째 주기</string>
     <string name="pair_rename_title">쌍 이름 바꾸기</string>
     <string name="pair_rename_label">이름</string>

--- a/app/src/main/res/values-kw/strings.xml
+++ b/app/src/main/res/values-kw/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pep eur</string>
     <string name="pair_bought">prennys</string>
     <string name="pair_daily_hours_14">eur pep dydh (14 seythen)</string>
+    <string name="pair_charge_cycles">kylghow charjya</string>
+    <string name="pair_per_charge">pub charj</string>
+    <string name="pair_cycles">kylghow</string>
+    <string name="pair_charge_watched">mires</string>
+    <string name="pair_cycle_number">kylgh %1$d</string>
     <string name="pair_rename_title">adnevra par</string>
     <string name="pair_rename_label">anow</string>
     <string name="pair_retire_title">kas-hevel par na</string>

--- a/app/src/main/res/values-kw/strings.xml
+++ b/app/src/main/res/values-kw/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pub charj</string>
     <string name="pair_cycles">kylghow</string>
     <string name="pair_charge_watched">mires</string>
+    <string name="pair_vs_new">warbynn nowyth</string>
     <string name="pair_cycle_number">kylgh %1$d</string>
     <string name="pair_rename_title">adnevra par</string>
     <string name="pair_rename_label">anow</string>

--- a/app/src/main/res/values-ky/strings.xml
+++ b/app/src/main/res/values-ky/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">саат үчүн</string>
     <string name="pair_bought">сатып алынды</string>
     <string name="pair_daily_hours_14">күндүк сааттар (14 күн)</string>
+    <string name="pair_charge_cycles">заряддоо циклдери</string>
+    <string name="pair_per_charge">бир зарядга</string>
+    <string name="pair_cycles">циклдер</string>
+    <string name="pair_charge_watched">байкалган</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жубасын кайра аталандыруу</string>
     <string name="pair_rename_label">ат</string>
     <string name="pair_retire_title">бул жубасын пенсионго чыгаруу</string>

--- a/app/src/main/res/values-ky/strings.xml
+++ b/app/src/main/res/values-ky/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">бир зарядга</string>
     <string name="pair_cycles">циклдер</string>
     <string name="pair_charge_watched">байкалган</string>
+    <string name="pair_vs_new">жаңы кезине салыштырмалуу</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">жубасын кайра аталандыруу</string>
     <string name="pair_rename_label">ат</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro luedung</string>
     <string name="pair_cycles">zyklen</string>
     <string name="pair_charge_watched">beobaacht</string>
+    <string name="pair_vs_new">am Verglach mat nei</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ëmbenenne</string>
     <string name="pair_rename_label">non</string>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pro stonn</string>
     <string name="pair_bought">kaaft</string>
     <string name="pair_daily_hours_14">dägel stonnen (14 deeg)</string>
+    <string name="pair_charge_cycles">luetzyklen</string>
+    <string name="pair_per_charge">pro luedung</string>
+    <string name="pair_cycles">zyklen</string>
+    <string name="pair_charge_watched">beobaacht</string>
+    <string name="pair_cycle_number">zyklus %1$d</string>
     <string name="pair_rename_title">paar ëmbenenne</string>
     <string name="pair_rename_label">non</string>
     <string name="pair_retire_title">dësen paar pensionéieren</string>

--- a/app/src/main/res/values-lg/strings.xml
+++ b/app/src/main/res/values-lg/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">buli ssaawa</string>
     <string name="pair_bought">okugula</string>
     <string name="pair_daily_hours_14">essaawa z’ennaku (ennaku 14)</string>
+    <string name="pair_charge_cycles">enkyukakyuka z’amaanyi</string>
+    <string name="pair_per_charge">buli maanyi</string>
+    <string name="pair_cycles">enkyukakyuka</string>
+    <string name="pair_charge_watched">ekyalabiddwa</string>
+    <string name="pair_cycle_number">enkyukakyuka %1$d</string>
     <string name="pair_rename_title">andika erinnya mpya eri paale</string>
     <string name="pair_rename_label">erinnya</string>
     <string name="pair_retire_title">yikira paale eno</string>

--- a/app/src/main/res/values-lg/strings.xml
+++ b/app/src/main/res/values-lg/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">buli maanyi</string>
     <string name="pair_cycles">enkyukakyuka</string>
     <string name="pair_charge_watched">ekyalabiddwa</string>
+    <string name="pair_vs_new">okugeraageranya n’empya</string>
     <string name="pair_cycle_number">enkyukakyuka %1$d</string>
     <string name="pair_rename_title">andika erinnya mpya eri paale</string>
     <string name="pair_rename_label">erinnya</string>

--- a/app/src/main/res/values-ln/strings.xml
+++ b/app/src/main/res/values-ln/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na kotondisa mokó</string>
     <string name="pair_cycles">bazínga</string>
     <string name="pair_charge_watched">etálámákí</string>
+    <string name="pair_vs_new">na kotala na sika</string>
     <string name="pair_cycle_number">zínga %1$d</string>
     <string name="pair_rename_title">sunga nkombo ya makambo</string>
     <string name="pair_rename_label">nkombo</string>

--- a/app/src/main/res/values-ln/strings.xml
+++ b/app/src/main/res/values-ln/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pro myele</string>
     <string name="pair_bought">kulaki</string>
     <string name="pair_daily_hours_14">myele ya mokolo (mikolo 14)</string>
+    <string name="pair_charge_cycles">bazínga ya kotondisa</string>
+    <string name="pair_per_charge">na kotondisa mokó</string>
+    <string name="pair_cycles">bazínga</string>
+    <string name="pair_charge_watched">etálámákí</string>
+    <string name="pair_cycle_number">zínga %1$d</string>
     <string name="pair_rename_title">sunga nkombo ya makambo</string>
     <string name="pair_rename_label">nkombo</string>
     <string name="pair_retire_title">elekidi makambo oyo</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ຕໍ່ການສາກ</string>
     <string name="pair_cycles">ຮອບ</string>
     <string name="pair_charge_watched">ສັງເກດໄດ້</string>
+    <string name="pair_vs_new">ທຽບກັບຕອນໃໝ່</string>
     <string name="pair_cycle_number">ຮອບ %1$d</string>
     <string name="pair_rename_title">ປ່ຽນຊື່ຄູ່</string>
     <string name="pair_rename_label">ຊື່</string>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ຕໍ່ຊົ່ວໂມງ</string>
     <string name="pair_bought">ຊື້</string>
     <string name="pair_daily_hours_14">ຊົ່ວໂມງ 14 ວັນ</string>
+    <string name="pair_charge_cycles">ຮອບການສາກ</string>
+    <string name="pair_per_charge">ຕໍ່ການສາກ</string>
+    <string name="pair_cycles">ຮອບ</string>
+    <string name="pair_charge_watched">ສັງເກດໄດ້</string>
+    <string name="pair_cycle_number">ຮອບ %1$d</string>
     <string name="pair_rename_title">ປ່ຽນຊື່ຄູ່</string>
     <string name="pair_rename_label">ຊື່</string>
     <string name="pair_retire_title">ອອກຄູ່ນີ້</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">vienam įkrovimui</string>
     <string name="pair_cycles">ciklai</string>
     <string name="pair_charge_watched">stebėta</string>
+    <string name="pair_vs_new">palyginti su naujomis</string>
     <string name="pair_cycle_number">ciklas %1$d</string>
     <string name="pair_rename_title">pervadinti pora</string>
     <string name="pair_rename_label">vardas</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per valanda</string>
     <string name="pair_bought">nupirkta</string>
     <string name="pair_daily_hours_14">dienos valandos 14 dienu</string>
+    <string name="pair_charge_cycles">įkrovimo ciklai</string>
+    <string name="pair_per_charge">vienam įkrovimui</string>
+    <string name="pair_cycles">ciklai</string>
+    <string name="pair_charge_watched">stebėta</string>
+    <string name="pair_cycle_number">ciklas %1$d</string>
     <string name="pair_rename_title">pervadinti pora</string>
     <string name="pair_rename_label">vardas</string>
     <string name="pair_retire_title">pensija sia pora</string>

--- a/app/src/main/res/values-lu/strings.xml
+++ b/app/src/main/res/values-lu/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa saati</string>
     <string name="pair_bought">kanuntie</string>
     <string name="pair_daily_hours_14">saatisi za masawu</string>
+    <string name="pair_charge_cycles">mizungu ya bukome</string>
+    <string name="pair_per_charge">ku bukome bumo</string>
+    <string name="pair_cycles">mizungu</string>
+    <string name="pair_charge_watched">kutalwa</string>
+    <string name="pair_cycle_number">muzungu %1$d</string>
     <string name="pair_rename_title">kabuakile zina kikalangishi</string>
     <string name="pair_rename_label">zina</string>
     <string name="pair_retire_title">leta mu busemi kikalangishi</string>

--- a/app/src/main/res/values-lu/strings.xml
+++ b/app/src/main/res/values-lu/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ku bukome bumo</string>
     <string name="pair_cycles">mizungu</string>
     <string name="pair_charge_watched">kutalwa</string>
+    <string name="pair_vs_new">pa kutentekesha ne bipya</string>
     <string name="pair_cycle_number">muzungu %1$d</string>
     <string name="pair_rename_title">kabuakile zina kikalangishi</string>
     <string name="pair_rename_label">zina</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">uz vienu uzlādi</string>
     <string name="pair_cycles">cikli</string>
     <string name="pair_charge_watched">novērots</string>
+    <string name="pair_vs_new">salīdzinot ar jaunām</string>
     <string name="pair_cycle_number">%1$d. cikls</string>
     <string name="pair_rename_title">pārdēvēt pāri</string>
     <string name="pair_rename_label">nosaukums</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">stundā</string>
     <string name="pair_bought">nopirkts</string>
     <string name="pair_daily_hours_14">stundas dienā (14 dienas)</string>
+    <string name="pair_charge_cycles">uzlādes cikli</string>
+    <string name="pair_per_charge">uz vienu uzlādi</string>
+    <string name="pair_cycles">cikli</string>
+    <string name="pair_charge_watched">novērots</string>
+    <string name="pair_cycle_number">%1$d. cikls</string>
     <string name="pair_rename_title">pārdēvēt pāri</string>
     <string name="pair_rename_label">nosaukums</string>
     <string name="pair_retire_title">nodot šo pāri pensijā</string>

--- a/app/src/main/res/values-mg/strings.xml
+++ b/app/src/main/res/values-mg/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">isan’ora</string>
     <string name="pair_bought">novidiana</string>
     <string name="pair_daily_hours_14">ora isan’andro (14 andro)</string>
+    <string name="pair_charge_cycles">tsingerin’ny fameno</string>
+    <string name="pair_per_charge">isaky ny fameno</string>
+    <string name="pair_cycles">tsingerina</string>
+    <string name="pair_charge_watched">voamarika</string>
+    <string name="pair_cycle_number">tsingerina %1$d</string>
     <string name="pair_rename_title">ovay ny anaran’ny aurikilara</string>
     <string name="pair_rename_label">anarana</string>
     <string name="pair_retire_title">esory ity aurikilara ity</string>

--- a/app/src/main/res/values-mg/strings.xml
+++ b/app/src/main/res/values-mg/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">isaky ny fameno</string>
     <string name="pair_cycles">tsingerina</string>
     <string name="pair_charge_watched">voamarika</string>
+    <string name="pair_vs_new">raha oharina amin’ny vaovao</string>
     <string name="pair_cycle_number">tsingerina %1$d</string>
     <string name="pair_rename_title">ovay ny anaran’ny aurikilara</string>
     <string name="pair_rename_label">anarana</string>

--- a/app/src/main/res/values-mi/strings.xml
+++ b/app/src/main/res/values-mi/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ia whakakī</string>
     <string name="pair_cycles">hurihanga</string>
     <string name="pair_charge_watched">i mātakitakihia</string>
+    <string name="pair_vs_new">ki te whakatauritenga hou</string>
     <string name="pair_cycle_number">hurihanga %1$d</string>
     <string name="pair_rename_title">whakaingoa anō i te takirua</string>
     <string name="pair_rename_label">ingoa</string>

--- a/app/src/main/res/values-mi/strings.xml
+++ b/app/src/main/res/values-mi/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ia hāora</string>
     <string name="pair_bought">i hokona</string>
     <string name="pair_daily_hours_14">hāora ia rā (14 rā)</string>
+    <string name="pair_charge_cycles">ngā hurihanga whakakī</string>
+    <string name="pair_per_charge">ia whakakī</string>
+    <string name="pair_cycles">hurihanga</string>
+    <string name="pair_charge_watched">i mātakitakihia</string>
+    <string name="pair_cycle_number">hurihanga %1$d</string>
     <string name="pair_rename_title">whakaingoa anō i te takirua</string>
     <string name="pair_rename_label">ingoa</string>
     <string name="pair_retire_title">whakatā i tēnei takirua</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">по полнење</string>
     <string name="pair_cycles">циклуси</string>
     <string name="pair_charge_watched">набљудувано</string>
+    <string name="pair_vs_new">во однос на нови</string>
     <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименувај пар</string>
     <string name="pair_rename_label">име</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">на час</string>
     <string name="pair_bought">купено</string>
     <string name="pair_daily_hours_14">дневни часови (14 дена)</string>
+    <string name="pair_charge_cycles">циклуси на полнење</string>
+    <string name="pair_per_charge">по полнење</string>
+    <string name="pair_cycles">циклуси</string>
+    <string name="pair_charge_watched">набљудувано</string>
+    <string name="pair_cycle_number">циклус %1$d</string>
     <string name="pair_rename_title">преименувај пар</string>
     <string name="pair_rename_label">име</string>
     <string name="pair_retire_title">пензионирај го овој пар</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">മണിക്കൂറിന്</string>
     <string name="pair_bought">വാങ്ങിയത്</string>
     <string name="pair_daily_hours_14">ദിവസേനയുള്ള മണിക്കൂർ (14 ദിവസം)</string>
+    <string name="pair_charge_cycles">ചാർജ് ചക്രങ്ങൾ</string>
+    <string name="pair_per_charge">ഓരോ ചാർജിനും</string>
+    <string name="pair_cycles">ചക്രങ്ങൾ</string>
+    <string name="pair_charge_watched">നിരീക്ഷിച്ചത്</string>
+    <string name="pair_cycle_number">ചക്രം %1$d</string>
     <string name="pair_rename_title">ജോടിയുടെ പേര് മാറ്റുക</string>
     <string name="pair_rename_label">പേര്</string>
     <string name="pair_retire_title">ഈ ജോടി വിരമിപ്പിക്കുക</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ഓരോ ചാർജിനും</string>
     <string name="pair_cycles">ചക്രങ്ങൾ</string>
     <string name="pair_charge_watched">നിരീക്ഷിച്ചത്</string>
+    <string name="pair_vs_new">പുതിയതിനെ അപേക്ഷിച്ച്</string>
     <string name="pair_cycle_number">ചക്രം %1$d</string>
     <string name="pair_rename_title">ജോടിയുടെ പേര് മാറ്റുക</string>
     <string name="pair_rename_label">പേര്</string>

--- a/app/src/main/res/values-mn/strings.xml
+++ b/app/src/main/res/values-mn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">цагт</string>
     <string name="pair_bought">худалдаж авсан</string>
     <string name="pair_daily_hours_14">өдрийн цаг (14 хоног)</string>
+    <string name="pair_charge_cycles">цэнэглэх мөчлөг</string>
+    <string name="pair_per_charge">нэг цэнэгт</string>
+    <string name="pair_cycles">мөчлөг</string>
+    <string name="pair_charge_watched">ажигласан</string>
+    <string name="pair_cycle_number">мөчлөг %1$d</string>
     <string name="pair_rename_title">хосын нэрийг солих</string>
     <string name="pair_rename_label">нэр</string>
     <string name="pair_retire_title">энэ хосыг тэтгэвэрт гаргах</string>

--- a/app/src/main/res/values-mn/strings.xml
+++ b/app/src/main/res/values-mn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">нэг цэнэгт</string>
     <string name="pair_cycles">мөчлөг</string>
     <string name="pair_charge_watched">ажигласан</string>
+    <string name="pair_vs_new">шинэ байхтай харьцуулбал</string>
     <string name="pair_cycle_number">мөчлөг %1$d</string>
     <string name="pair_rename_title">хосын нэрийг солих</string>
     <string name="pair_rename_label">нэр</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">प्रति चार्ज</string>
     <string name="pair_cycles">चक्रे</string>
     <string name="pair_charge_watched">निरीक्षण केलेले</string>
+    <string name="pair_vs_new">नवीन असतानाच्या तुलनेत</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीचं नाव बदला</string>
     <string name="pair_rename_label">नाव</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रति तास</string>
     <string name="pair_bought">खरेदी केलं</string>
     <string name="pair_daily_hours_14">रोजचे तास (१४ दिवस)</string>
+    <string name="pair_charge_cycles">चार्ज चक्रे</string>
+    <string name="pair_per_charge">प्रति चार्ज</string>
+    <string name="pair_cycles">चक्रे</string>
+    <string name="pair_charge_watched">निरीक्षण केलेले</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीचं नाव बदला</string>
     <string name="pair_rename_label">नाव</string>
     <string name="pair_retire_title">ही जोडी निवृत्त करा</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">sejam</string>
     <string name="pair_bought">dibeli</string>
     <string name="pair_daily_hours_14">jam harian (14 hari)</string>
+    <string name="pair_charge_cycles">kitaran cas</string>
+    <string name="pair_per_charge">setiap cas</string>
+    <string name="pair_cycles">kitaran</string>
+    <string name="pair_charge_watched">diperhati</string>
+    <string name="pair_cycle_number">kitaran %1$d</string>
     <string name="pair_rename_title">namakan semula pasangan</string>
     <string name="pair_rename_label">nama</string>
     <string name="pair_retire_title">bersarakan pasangan ini</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">setiap cas</string>
     <string name="pair_cycles">kitaran</string>
     <string name="pair_charge_watched">diperhati</string>
+    <string name="pair_vs_new">berbanding semasa baharu</string>
     <string name="pair_cycle_number">kitaran %1$d</string>
     <string name="pair_rename_title">namakan semula pasangan</string>
     <string name="pair_rename_label">nama</string>

--- a/app/src/main/res/values-mt/strings.xml
+++ b/app/src/main/res/values-mt/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kull siegħa</string>
     <string name="pair_bought">żtrajt</string>
     <string name="pair_daily_hours_14">sigħat kuljum (14 ġimgħat)</string>
+    <string name="pair_charge_cycles">ċikli taċ-ċarġ</string>
+    <string name="pair_per_charge">kull ċarġ</string>
+    <string name="pair_cycles">ċikli</string>
+    <string name="pair_charge_watched">osservat</string>
+    <string name="pair_cycle_number">ċiklu %1$d</string>
     <string name="pair_rename_title">isemmi l-par mill-ġdid</string>
     <string name="pair_rename_label">isem</string>
     <string name="pair_retire_title">ritira l-par din</string>

--- a/app/src/main/res/values-mt/strings.xml
+++ b/app/src/main/res/values-mt/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kull ċarġ</string>
     <string name="pair_cycles">ċikli</string>
     <string name="pair_charge_watched">osservat</string>
+    <string name="pair_vs_new">imqabbla ma’ ġodda</string>
     <string name="pair_cycle_number">ċiklu %1$d</string>
     <string name="pair_rename_title">isemmi l-par mill-ġdid</string>
     <string name="pair_rename_label">isem</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">တစ်နာရီလျှင်</string>
     <string name="pair_bought">ဆိုင်းဖြုတ်</string>
     <string name="pair_daily_hours_14">နေ့စဉ်နာရီ (14 ရက်)</string>
+    <string name="pair_charge_cycles">အားသွင်းသံသရာ</string>
+    <string name="pair_per_charge">တစ်ကြိမ်အားသွင်းလျှင်</string>
+    <string name="pair_cycles">သံသရာ</string>
+    <string name="pair_charge_watched">စောင့်ကြည့်ခဲ့</string>
+    <string name="pair_cycle_number">သံသရာ %1$d</string>
     <string name="pair_rename_title">အတွဲကို အမည်ပြောင်းရန်</string>
     <string name="pair_rename_label">အစည်း</string>
     <string name="pair_retire_title">ဤအတွဲကို အနားပေးရန်</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">တစ်ကြိမ်အားသွင်းလျှင်</string>
     <string name="pair_cycles">သံသရာ</string>
     <string name="pair_charge_watched">စောင့်ကြည့်ခဲ့</string>
+    <string name="pair_vs_new">အသစ်နှင့်နှိုင်းယှဉ်</string>
     <string name="pair_cycle_number">သံသရာ %1$d</string>
     <string name="pair_rename_title">အတွဲကို အမည်ပြောင်းရန်</string>
     <string name="pair_rename_label">အစည်း</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_per_charge">per lading</string>
     <string name="pair_cycles">sykluser</string>
     <string name="pair_charge_watched">observert</string>
+    <string name="pair_vs_new">mot da de var nye</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">gi paret nytt navn</string>
     <string name="pair_rename_label">navn</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -100,6 +100,11 @@
     <string name="pair_per_hour">per time</string>
     <string name="pair_bought">kjøpt</string>
     <string name="pair_daily_hours_14">timer per dag (14 dager)</string>
+    <string name="pair_charge_cycles">ladesykluser</string>
+    <string name="pair_per_charge">per lading</string>
+    <string name="pair_cycles">sykluser</string>
+    <string name="pair_charge_watched">observert</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">gi paret nytt navn</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">pensjonér dette paret</string>

--- a/app/src/main/res/values-nd/strings.xml
+++ b/app/src/main/res/values-nd/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ngokugcwalisa okukodwa</string>
     <string name="pair_cycles">izigaba</string>
     <string name="pair_charge_watched">okubonwe</string>
+    <string name="pair_vs_new">uma kuqathaniswa lokutsha</string>
     <string name="pair_cycle_number">isigaba %1$d</string>
     <string name="pair_rename_title">ubuyisele igama lemsulwa</string>
     <string name="pair_rename_label">igama</string>

--- a/app/src/main/res/values-nd/strings.xml
+++ b/app/src/main/res/values-nd/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ngeawu</string>
     <string name="pair_bought">kuthenge</string>
     <string name="pair_daily_hours_14">iawu ngosuku (amalanga angama-14)</string>
+    <string name="pair_charge_cycles">izigaba zokugcwalisa</string>
+    <string name="pair_per_charge">ngokugcwalisa okukodwa</string>
+    <string name="pair_cycles">izigaba</string>
+    <string name="pair_charge_watched">okubonwe</string>
+    <string name="pair_cycle_number">isigaba %1$d</string>
     <string name="pair_rename_title">ubuyisele igama lemsulwa</string>
     <string name="pair_rename_label">igama</string>
     <string name="pair_retire_title">umekhele lemsulwa omusha</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रति घण्टा</string>
     <string name="pair_bought">खरीद गरिएको</string>
     <string name="pair_daily_hours_14">दैनिक घण्टा (14 दिन)</string>
+    <string name="pair_charge_cycles">चार्ज चक्रहरू</string>
+    <string name="pair_per_charge">प्रति चार्ज</string>
+    <string name="pair_cycles">चक्रहरू</string>
+    <string name="pair_charge_watched">अवलोकन गरिएको</string>
+    <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीलाई नामबदल गर्नुहोस्</string>
     <string name="pair_rename_label">नाम</string>
     <string name="pair_retire_title">यो जोडीलाई सेवानिवृत्त गर्नुहोस्</string>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">प्रति चार्ज</string>
     <string name="pair_cycles">चक्रहरू</string>
     <string name="pair_charge_watched">अवलोकन गरिएको</string>
+    <string name="pair_vs_new">नयाँ हुँदाको तुलनामा</string>
     <string name="pair_cycle_number">चक्र %1$d</string>
     <string name="pair_rename_title">जोडीलाई नामबदल गर्नुहोस्</string>
     <string name="pair_rename_label">नाम</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">per lading</string>
     <string name="pair_cycles">cycli</string>
     <string name="pair_charge_watched">waargenomen</string>
+    <string name="pair_vs_new">ten opzichte van nieuw</string>
     <string name="pair_cycle_number">cyclus %1$d</string>
     <string name="pair_rename_title">koptelefoon hernoemen</string>
     <string name="pair_rename_label">naam</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">per uur</string>
     <string name="pair_bought">gekocht</string>
     <string name="pair_daily_hours_14">uren per dag (14 dagen)</string>
+    <string name="pair_charge_cycles">laadcycli</string>
+    <string name="pair_per_charge">per lading</string>
+    <string name="pair_cycles">cycli</string>
+    <string name="pair_charge_watched">waargenomen</string>
+    <string name="pair_cycle_number">cyclus %1$d</string>
     <string name="pair_rename_title">koptelefoon hernoemen</string>
     <string name="pair_rename_label">naam</string>
     <string name="pair_retire_title">deze koptelefoon pensioneren</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per lading</string>
     <string name="pair_cycles">syklusar</string>
     <string name="pair_charge_watched">observert</string>
+    <string name="pair_vs_new">mot då dei var nye</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">endr namn på par</string>
     <string name="pair_rename_label">namn</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per time</string>
     <string name="pair_bought">kjøpt</string>
     <string name="pair_daily_hours_14">dagleg timar (14 dagar)</string>
+    <string name="pair_charge_cycles">ladesyklusar</string>
+    <string name="pair_per_charge">per lading</string>
+    <string name="pair_cycles">syklusar</string>
+    <string name="pair_charge_watched">observert</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">endr namn på par</string>
     <string name="pair_rename_label">namn</string>
     <string name="pair_retire_title">pensjonere dette paret</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ଘଣ୍ଟା ପିଛା</string>
     <string name="pair_bought">କିଣାଯାଇଛି</string>
     <string name="pair_daily_hours_14">ଦୈନିକ ଘଣ୍ଟା (୧୪ ଦିନ)</string>
+    <string name="pair_charge_cycles">ଚାର୍ଜ ଚକ୍ର</string>
+    <string name="pair_per_charge">ପ୍ରତି ଚାର୍ଜରେ</string>
+    <string name="pair_cycles">ଚକ୍ର</string>
+    <string name="pair_charge_watched">ପର୍ଯ୍ୟବେକ୍ଷିତ</string>
+    <string name="pair_cycle_number">ଚକ୍ର %1$d</string>
     <string name="pair_rename_title">ଯୋଡ଼ିର ନାମ ବଦଳାନ୍ତୁ</string>
     <string name="pair_rename_label">ନାମ</string>
     <string name="pair_retire_title">ଏହି ଯୋଡ଼ିକୁ ଅବସର ଦିଅନ୍ତୁ</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ପ୍ରତି ଚାର୍ଜରେ</string>
     <string name="pair_cycles">ଚକ୍ର</string>
     <string name="pair_charge_watched">ପର୍ଯ୍ୟବେକ୍ଷିତ</string>
+    <string name="pair_vs_new">ନୂଆ ଥିବା ସମୟ ତୁଳନାରେ</string>
     <string name="pair_cycle_number">ଚକ୍ର %1$d</string>
     <string name="pair_rename_title">ଯୋଡ଼ିର ନାମ ବଦଳାନ୍ତୁ</string>
     <string name="pair_rename_label">ନାମ</string>

--- a/app/src/main/res/values-os/strings.xml
+++ b/app/src/main/res/values-os/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">сахатмӕ</string>
     <string name="pair_bought">балхӕд</string>
     <string name="pair_daily_hours_14">боны сахӕттӕ (14 боны)</string>
+    <string name="pair_charge_cycles">зарядкæйы циклтæ</string>
+    <string name="pair_per_charge">иу зарядыл</string>
+    <string name="pair_cycles">циклтæ</string>
+    <string name="pair_charge_watched">цæст дарынц</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">парӕйӕн ном ивын</string>
     <string name="pair_rename_label">ном</string>
     <string name="pair_retire_title">ацы парӕ ныууадз</string>

--- a/app/src/main/res/values-os/strings.xml
+++ b/app/src/main/res/values-os/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">иу зарядыл</string>
     <string name="pair_cycles">циклтæ</string>
     <string name="pair_charge_watched">цæст дарынц</string>
+    <string name="pair_vs_new">ног уыдысты, уыимæ абаргæйæ</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">парӕйӕн ном ивын</string>
     <string name="pair_rename_label">ном</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">na ładowanie</string>
     <string name="pair_cycles">cykle</string>
     <string name="pair_charge_watched">zaobserwowano</string>
+    <string name="pair_vs_new">wobec nowych</string>
     <string name="pair_cycle_number">cykl %1$d</string>
     <string name="pair_rename_title">zmień nazwę pary</string>
     <string name="pair_rename_label">nazwa</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">za godzinę</string>
     <string name="pair_bought">kupiono</string>
     <string name="pair_daily_hours_14">godziny dziennie (14 dni)</string>
+    <string name="pair_charge_cycles">cykle ładowania</string>
+    <string name="pair_per_charge">na ładowanie</string>
+    <string name="pair_cycles">cykle</string>
+    <string name="pair_charge_watched">zaobserwowano</string>
+    <string name="pair_cycle_number">cykl %1$d</string>
     <string name="pair_rename_title">zmień nazwę pary</string>
     <string name="pair_rename_label">nazwa</string>
     <string name="pair_retire_title">wycofaj tę parę</string>

--- a/app/src/main/res/values-ps/strings.xml
+++ b/app/src/main/res/values-ps/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">په هر چارج</string>
     <string name="pair_cycles">دورې</string>
     <string name="pair_charge_watched">کتل شوی</string>
+    <string name="pair_vs_new">د نوي په پرتله</string>
     <string name="pair_cycle_number">دوره %1$d</string>
     <string name="pair_rename_title">جوړه نوم بدل کړئ</string>
     <string name="pair_rename_label">نوم</string>

--- a/app/src/main/res/values-ps/strings.xml
+++ b/app/src/main/res/values-ps/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">هر ساعت</string>
     <string name="pair_bought">خریدل شوی</string>
     <string name="pair_daily_hours_14">روزمره ساعتونه (14 ورځې)</string>
+    <string name="pair_charge_cycles">د چارج دورې</string>
+    <string name="pair_per_charge">په هر چارج</string>
+    <string name="pair_cycles">دورې</string>
+    <string name="pair_charge_watched">کتل شوی</string>
+    <string name="pair_cycle_number">دوره %1$d</string>
     <string name="pair_rename_title">جوړه نوم بدل کړئ</string>
     <string name="pair_rename_label">نوم</string>
     <string name="pair_retire_title">دا جوړه لرې کړئ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">por carga</string>
     <string name="pair_cycles">ciclos</string>
     <string name="pair_charge_watched">observado</string>
+    <string name="pair_vs_new">em relação a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">por hora</string>
     <string name="pair_bought">comprado</string>
     <string name="pair_daily_hours_14">horas diárias (14 dias)</string>
+    <string name="pair_charge_cycles">ciclos de carga</string>
+    <string name="pair_per_charge">por carga</string>
+    <string name="pair_cycles">ciclos</string>
+    <string name="pair_charge_watched">observado</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">aposentar este par</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">por carga</string>
     <string name="pair_cycles">ciclos</string>
     <string name="pair_charge_watched">observado</string>
+    <string name="pair_vs_new">em relação a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">por hora</string>
     <string name="pair_bought">comprado</string>
     <string name="pair_daily_hours_14">horas diárias (14 dias)</string>
+    <string name="pair_charge_cycles">ciclos de carga</string>
+    <string name="pair_per_charge">por carga</string>
+    <string name="pair_cycles">ciclos</string>
+    <string name="pair_charge_watched">observado</string>
+    <string name="pair_cycle_number">ciclo %1$d</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">aposentar este par</string>

--- a/app/src/main/res/values-qu/strings.xml
+++ b/app/src/main/res/values-qu/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">sapa hunt’achiypi</string>
     <string name="pair_cycles">muyuykuna</string>
     <string name="pair_charge_watched">qhawasqa</string>
+    <string name="pair_vs_new">musuq kaptin tupachisqa</string>
     <string name="pair_cycle_number">muyuy %1$d</string>
     <string name="pair_rename_title">pares sutiyamuy</string>
     <string name="pair_rename_label">suti</string>

--- a/app/src/main/res/values-qu/strings.xml
+++ b/app/src/main/res/values-qu/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">horawta</string>
     <string name="pair_bought">rantisqa</string>
     <string name="pair_daily_hours_14">punchau oras (14 oras)</string>
+    <string name="pair_charge_cycles">hunt’achiy muyuykuna</string>
+    <string name="pair_per_charge">sapa hunt’achiypi</string>
+    <string name="pair_cycles">muyuykuna</string>
+    <string name="pair_charge_watched">qhawasqa</string>
+    <string name="pair_cycle_number">muyuy %1$d</string>
     <string name="pair_rename_title">pares sutiyamuy</string>
     <string name="pair_rename_label">suti</string>
     <string name="pair_retire_title">kay pares retira</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">per chargia</string>
     <string name="pair_cycles">ciclus</string>
     <string name="pair_charge_watched">observà</string>
+    <string name="pair_vs_new">en congual cun nov</string>
     <string name="pair_cycle_number">ciclus %1$d</string>
     <string name="pair_rename_title">renumner pair</string>
     <string name="pair_rename_label">num</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per ura</string>
     <string name="pair_bought">cumpra</string>
     <string name="pair_daily_hours_14">uras giurnodas (14 dis)</string>
+    <string name="pair_charge_cycles">ciclus da chargia</string>
+    <string name="pair_per_charge">per chargia</string>
+    <string name="pair_cycles">ciclus</string>
+    <string name="pair_charge_watched">observà</string>
+    <string name="pair_cycle_number">ciclus %1$d</string>
     <string name="pair_rename_title">renumner pair</string>
     <string name="pair_rename_label">num</string>
     <string name="pair_retire_title">pensiunar questa pair</string>

--- a/app/src/main/res/values-rn/strings.xml
+++ b/app/src/main/res/values-rn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ku ngoga imwe</string>
     <string name="pair_cycles">ibizunguruko</string>
     <string name="pair_charge_watched">vyabonywe</string>
+    <string name="pair_vs_new">ugereranije n’agashasha</string>
     <string name="pair_cycle_number">igizunguruko %1$d</string>
     <string name="pair_rename_title">fata izina ry’inzira</string>
     <string name="pair_rename_label">izina</string>

--- a/app/src/main/res/values-rn/strings.xml
+++ b/app/src/main/res/values-rn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">buri masaha</string>
     <string name="pair_bought">yabitswe</string>
     <string name="pair_daily_hours_14">amasaha buri munsi (iminsi 14)</string>
+    <string name="pair_charge_cycles">ibizunguruko vy’ingoga</string>
+    <string name="pair_per_charge">ku ngoga imwe</string>
+    <string name="pair_cycles">ibizunguruko</string>
+    <string name="pair_charge_watched">vyabonywe</string>
+    <string name="pair_cycle_number">igizunguruko %1$d</string>
     <string name="pair_rename_title">fata izina ry’inzira</string>
     <string name="pair_rename_label">izina</string>
     <string name="pair_retire_title">tereka iyi nzira</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">pe oră</string>
     <string name="pair_bought">cumpărată</string>
     <string name="pair_daily_hours_14">ore pe zi (14 zile)</string>
+    <string name="pair_charge_cycles">cicluri de încărcare</string>
+    <string name="pair_per_charge">pe încărcare</string>
+    <string name="pair_cycles">cicluri</string>
+    <string name="pair_charge_watched">observat</string>
+    <string name="pair_cycle_number">ciclul %1$d</string>
     <string name="pair_rename_title">redenumește perechea</string>
     <string name="pair_rename_label">nume</string>
     <string name="pair_retire_title">retrage această pereche</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">pe încărcare</string>
     <string name="pair_cycles">cicluri</string>
     <string name="pair_charge_watched">observat</string>
+    <string name="pair_vs_new">față de noi</string>
     <string name="pair_cycle_number">ciclul %1$d</string>
     <string name="pair_rename_title">redenumește perechea</string>
     <string name="pair_rename_label">nume</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -101,6 +101,7 @@
     <string name="pair_per_charge">на один заряд</string>
     <string name="pair_cycles">циклы</string>
     <string name="pair_charge_watched">под наблюдением</string>
+    <string name="pair_vs_new">по сравнению с новыми</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">переименовать пару</string>
     <string name="pair_rename_label">имя</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -97,6 +97,11 @@
     <string name="pair_per_hour">за час</string>
     <string name="pair_bought">куплены</string>
     <string name="pair_daily_hours_14">часы по дням (14 дней)</string>
+    <string name="pair_charge_cycles">циклы зарядки</string>
+    <string name="pair_per_charge">на один заряд</string>
+    <string name="pair_cycles">циклы</string>
+    <string name="pair_charge_watched">под наблюдением</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">переименовать пару</string>
     <string name="pair_rename_label">имя</string>
     <string name="pair_retire_title">списать эту пару</string>

--- a/app/src/main/res/values-rw/strings.xml
+++ b/app/src/main/res/values-rw/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kuri buri gushyiramo</string>
     <string name="pair_cycles">ibizunguruko</string>
     <string name="pair_charge_watched">byagaragajwe</string>
+    <string name="pair_vs_new">ugereranyije n’ibishya</string>
     <string name="pair_cycle_number">igizunguruko %1$d</string>
     <string name="pair_rename_title">fata izina ry’ibiyobo</string>
     <string name="pair_rename_label">izina</string>

--- a/app/src/main/res/values-rw/strings.xml
+++ b/app/src/main/res/values-rw/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">buri masaha</string>
     <string name="pair_bought">yabitswe</string>
     <string name="pair_daily_hours_14">amasaha buri munsi (iminsi 14)</string>
+    <string name="pair_charge_cycles">ibizunguruko byo gushyiramo</string>
+    <string name="pair_per_charge">kuri buri gushyiramo</string>
+    <string name="pair_cycles">ibizunguruko</string>
+    <string name="pair_charge_watched">byagaragajwe</string>
+    <string name="pair_cycle_number">igizunguruko %1$d</string>
     <string name="pair_rename_title">fata izina ry’ibiyobo</string>
     <string name="pair_rename_label">izina</string>
     <string name="pair_retire_title">tereka iyi biyobo</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">प्रतिहोरम्</string>
     <string name="pair_bought">क्रीतम्</string>
     <string name="pair_daily_hours_14">दैनिकाः होराः (14 दिनानि)</string>
+    <string name="pair_charge_cycles">आवेशचक्राणि</string>
+    <string name="pair_per_charge">प्रत्यावेशम्</string>
+    <string name="pair_cycles">चक्राणि</string>
+    <string name="pair_charge_watched">अवलोकितम्</string>
+    <string name="pair_cycle_number">चक्रम् %1$d</string>
     <string name="pair_rename_title">युग्मस्य नाम परिवर्तयतु</string>
     <string name="pair_rename_label">नाम</string>
     <string name="pair_retire_title">इदं युग्मं निवर्तयतु</string>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">प्रत्यावेशम्</string>
     <string name="pair_cycles">चक्राणि</string>
     <string name="pair_charge_watched">अवलोकितम्</string>
+    <string name="pair_vs_new">नवीनतुलनायाम्</string>
     <string name="pair_cycle_number">चक्रम् %1$d</string>
     <string name="pair_rename_title">युग्मस्य नाम परिवर्तयतु</string>
     <string name="pair_rename_label">नाम</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">pro ora</string>
     <string name="pair_bought">cumpradu</string>
     <string name="pair_daily_hours_14">oras giurnadas (14 dies)</string>
+    <string name="pair_charge_cycles">tzìclos de càrriga</string>
+    <string name="pair_per_charge">pro càrriga</string>
+    <string name="pair_cycles">tzìclos</string>
+    <string name="pair_charge_watched">osservadu</string>
+    <string name="pair_cycle_number">tzìclu %1$d</string>
     <string name="pair_rename_title">bennomine para</string>
     <string name="pair_rename_label">nòmine</string>
     <string name="pair_retire_title">pensiona custa para</string>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pro càrriga</string>
     <string name="pair_cycles">tzìclos</string>
     <string name="pair_charge_watched">osservadu</string>
+    <string name="pair_vs_new">in cunfrontu a nois</string>
     <string name="pair_cycle_number">tzìclu %1$d</string>
     <string name="pair_rename_title">bennomine para</string>
     <string name="pair_rename_label">nòmine</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">vahkka maŋŋel</string>
     <string name="pair_bought">oastume</string>
     <string name="pair_daily_hours_14">beaivemearri (vahkka 14)</string>
+    <string name="pair_charge_cycles">láddensyklusat</string>
+    <string name="pair_per_charge">ládden nammii</string>
+    <string name="pair_cycles">syklusat</string>
+    <string name="pair_charge_watched">goziduvvon</string>
+    <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">mainna bohccu</string>
     <string name="pair_rename_label">namma</string>
     <string name="pair_retire_title">maiddáhttugovva dát bohccu</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ládden nammii</string>
     <string name="pair_cycles">syklusat</string>
     <string name="pair_charge_watched">goziduvvon</string>
+    <string name="pair_vs_new">ođđasiid ektui</string>
     <string name="pair_cycle_number">syklus %1$d</string>
     <string name="pair_rename_title">mainna bohccu</string>
     <string name="pair_rename_label">namma</string>

--- a/app/src/main/res/values-sg/strings.xml
+++ b/app/src/main/res/values-sg/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na sarze oko</string>
     <string name="pair_cycles">angoro</string>
     <string name="pair_charge_watched">abâ</string>
+    <string name="pair_vs_new">na fini</string>
     <string name="pair_cycle_number">ngoro %1$d</string>
     <string name="pair_rename_title">kobo mo famene sânda</string>
     <string name="pair_rename_label">famene</string>

--- a/app/src/main/res/values-sg/strings.xml
+++ b/app/src/main/res/values-sg/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">na ngö mo</string>
     <string name="pair_bought">bili</string>
     <string name="pair_daily_hours_14">ngö kûê (zêni 14)</string>
+    <string name="pair_charge_cycles">angoro ti sarze</string>
+    <string name="pair_per_charge">na sarze oko</string>
+    <string name="pair_cycles">angoro</string>
+    <string name="pair_charge_watched">abâ</string>
+    <string name="pair_cycle_number">ngoro %1$d</string>
     <string name="pair_rename_title">kobo mo famene sânda</string>
     <string name="pair_rename_label">famene</string>
     <string name="pair_retire_title">kobo mo kü</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">පැයි බැගින්</string>
     <string name="pair_bought">ගිණුම කරන්න</string>
     <string name="pair_daily_hours_14">දෛනික පැයි (දින 14)</string>
+    <string name="pair_charge_cycles">ආරෝපණ චක්‍ර</string>
+    <string name="pair_per_charge">ආරෝපණයකට</string>
+    <string name="pair_cycles">චක්‍ර</string>
+    <string name="pair_charge_watched">නිරීක්ෂණය කළ</string>
+    <string name="pair_cycle_number">චක්‍රය %1$d</string>
     <string name="pair_rename_title">යුගල නැවත නම් කරන්න</string>
     <string name="pair_rename_label">නම</string>
     <string name="pair_retire_title">එම යුගල විශ්‍රාම දෙන්න</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ආරෝපණයකට</string>
     <string name="pair_cycles">චක්‍ර</string>
     <string name="pair_charge_watched">නිරීක්ෂණය කළ</string>
+    <string name="pair_vs_new">අලුත් කාලයට සාපේක්ෂව</string>
     <string name="pair_cycle_number">චක්‍රය %1$d</string>
     <string name="pair_rename_title">යුගල නැවත නම් කරන්න</string>
     <string name="pair_rename_label">නම</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">za hodinu</string>
     <string name="pair_bought">kúpené</string>
     <string name="pair_daily_hours_14">denné hodiny (14 dní)</string>
+    <string name="pair_charge_cycles">nabíjacie cykly</string>
+    <string name="pair_per_charge">na nabitie</string>
+    <string name="pair_cycles">cykly</string>
+    <string name="pair_charge_watched">sledované</string>
+    <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">premenovať pár</string>
     <string name="pair_rename_label">meno</string>
     <string name="pair_retire_title">vyradiť tento pár</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na nabitie</string>
     <string name="pair_cycles">cykly</string>
     <string name="pair_charge_watched">sledované</string>
+    <string name="pair_vs_new">oproti novým</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
     <string name="pair_rename_title">premenovať pár</string>
     <string name="pair_rename_label">meno</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">na uro</string>
     <string name="pair_bought">kupljeno</string>
     <string name="pair_daily_hours_14">dnevne ure (14 dni)</string>
+    <string name="pair_charge_cycles">cikli polnjenja</string>
+    <string name="pair_per_charge">na polnjenje</string>
+    <string name="pair_cycles">cikli</string>
+    <string name="pair_charge_watched">opazovano</string>
+    <string name="pair_cycle_number">cikel %1$d</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">upokoji ta par</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">na polnjenje</string>
     <string name="pair_cycles">cikli</string>
     <string name="pair_charge_watched">opazovano</string>
+    <string name="pair_vs_new">glede na nove</string>
     <string name="pair_cycle_number">cikel %1$d</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>

--- a/app/src/main/res/values-sn/strings.xml
+++ b/app/src/main/res/values-sn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">pasimba rimwe</string>
     <string name="pair_cycles">matenderero</string>
     <string name="pair_charge_watched">zvakaonekwa</string>
+    <string name="pair_vs_new">kuenzanisa nemitsva</string>
     <string name="pair_cycle_number">tenderero %1$d</string>
     <string name="pair_rename_title">zvirudziro sora</string>
     <string name="pair_rename_label">zita</string>

--- a/app/src/main/res/values-sn/strings.xml
+++ b/app/src/main/res/values-sn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">panhema</string>
     <string name="pair_bought">kutenga</string>
     <string name="pair_daily_hours_14">mahora pazuva (14 mazuva)</string>
+    <string name="pair_charge_cycles">matenderero esimba</string>
+    <string name="pair_per_charge">pasimba rimwe</string>
+    <string name="pair_cycles">matenderero</string>
+    <string name="pair_charge_watched">zvakaonekwa</string>
+    <string name="pair_cycle_number">tenderero %1$d</string>
     <string name="pair_rename_title">zvirudziro sora</string>
     <string name="pair_rename_label">zita</string>
     <string name="pair_retire_title">bvisa sora iyi</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">dallacaad kasta</string>
     <string name="pair_cycles">wareegyo</string>
     <string name="pair_charge_watched">la ilaaliyay</string>
+    <string name="pair_vs_new">marka la barbardhigo cusub</string>
     <string name="pair_cycle_number">wareeg %1$d</string>
     <string name="pair_rename_title">labida gaarka</string>
     <string name="pair_rename_label">magaca</string>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">saacad kasta</string>
     <string name="pair_bought">iibiay</string>
     <string name="pair_daily_hours_14">saacadaha maalinlaha (14 maalinta)</string>
+    <string name="pair_charge_cycles">wareegyada dallacaadda</string>
+    <string name="pair_per_charge">dallacaad kasta</string>
+    <string name="pair_cycles">wareegyo</string>
+    <string name="pair_charge_watched">la ilaaliyay</string>
+    <string name="pair_cycle_number">wareeg %1$d</string>
     <string name="pair_rename_title">labida gaarka</string>
     <string name="pair_rename_label">magaca</string>
     <string name="pair_retire_title">iska bax gaarka</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">për karikim</string>
     <string name="pair_cycles">cikle</string>
     <string name="pair_charge_watched">vëzhguar</string>
+    <string name="pair_vs_new">krahasuar me të reja</string>
     <string name="pair_cycle_number">cikli %1$d</string>
     <string name="pair_rename_title">riemëro palën</string>
     <string name="pair_rename_label">emri</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">për orë</string>
     <string name="pair_bought">blerë</string>
     <string name="pair_daily_hours_14">orë ditore (14 ditë)</string>
+    <string name="pair_charge_cycles">cikle karikimi</string>
+    <string name="pair_per_charge">për karikim</string>
+    <string name="pair_cycles">cikle</string>
+    <string name="pair_charge_watched">vëzhguar</string>
+    <string name="pair_cycle_number">cikli %1$d</string>
     <string name="pair_rename_title">riemëro palën</string>
     <string name="pair_rename_label">emri</string>
     <string name="pair_retire_title">pensionojeni këtë palë</string>

--- a/app/src/main/res/values-st/strings.xml
+++ b/app/src/main/res/values-st/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ka tjhaja e le nngwe</string>
     <string name="pair_cycles">dipotoloho</string>
     <string name="pair_charge_watched">ho shebilwe</string>
+    <string name="pair_vs_new">ha e bapiswa le tse ntjha</string>
     <string name="pair_cycle_number">potoloho %1$d</string>
     <string name="pair_rename_title">reha para lebitso le lecha</string>
     <string name="pair_rename_label">lebitso</string>

--- a/app/src/main/res/values-st/strings.xml
+++ b/app/src/main/res/values-st/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ka hora</string>
     <string name="pair_bought">e rekiloe</string>
     <string name="pair_daily_hours_14">lihora tsa letsatsi le letsatsi (matsatsi a 14)</string>
+    <string name="pair_charge_cycles">dipotoloho tsa ho tjhaja</string>
+    <string name="pair_per_charge">ka tjhaja e le nngwe</string>
+    <string name="pair_cycles">dipotoloho</string>
+    <string name="pair_charge_watched">ho shebilwe</string>
+    <string name="pair_cycle_number">potoloho %1$d</string>
     <string name="pair_rename_title">reha para lebitso le lecha</string>
     <string name="pair_rename_label">lebitso</string>
     <string name="pair_retire_title">beha para ena phomolong</string>

--- a/app/src/main/res/values-su/strings.xml
+++ b/app/src/main/res/values-su/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">per jam</string>
     <string name="pair_bought">dibeuli</string>
     <string name="pair_daily_hours_14">jam sapopoé (14 poé)</string>
+    <string name="pair_charge_cycles">siklus ngecas</string>
+    <string name="pair_per_charge">unggal ngecas</string>
+    <string name="pair_cycles">siklus</string>
+    <string name="pair_charge_watched">katalungtik</string>
+    <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti ngaran pasangan</string>
     <string name="pair_rename_label">ngaran</string>
     <string name="pair_retire_title">pangsiunkeun pasangan ieu</string>

--- a/app/src/main/res/values-su/strings.xml
+++ b/app/src/main/res/values-su/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">unggal ngecas</string>
     <string name="pair_cycles">siklus</string>
     <string name="pair_charge_watched">katalungtik</string>
+    <string name="pair_vs_new">dibandingkeun waktu anyar</string>
     <string name="pair_cycle_number">siklus %1$d</string>
     <string name="pair_rename_title">ganti ngaran pasangan</string>
     <string name="pair_rename_label">ngaran</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">per timme</string>
     <string name="pair_bought">köpt</string>
     <string name="pair_daily_hours_14">timmar per dag (14 dagar)</string>
+    <string name="pair_charge_cycles">laddcykler</string>
+    <string name="pair_per_charge">per laddning</string>
+    <string name="pair_cycles">cykler</string>
+    <string name="pair_charge_watched">observerat</string>
+    <string name="pair_cycle_number">cykel %1$d</string>
     <string name="pair_rename_title">byt namn på par</string>
     <string name="pair_rename_label">namn</string>
     <string name="pair_retire_title">pensionera detta par</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">per laddning</string>
     <string name="pair_cycles">cykler</string>
     <string name="pair_charge_watched">observerat</string>
+    <string name="pair_vs_new">mot när de var nya</string>
     <string name="pair_cycle_number">cykel %1$d</string>
     <string name="pair_rename_title">byt namn på par</string>
     <string name="pair_rename_label">namn</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">kwa kila chaji</string>
     <string name="pair_cycles">mizunguko</string>
     <string name="pair_charge_watched">iliyotazamwa</string>
+    <string name="pair_vs_new">ikilinganishwa na mpya</string>
     <string name="pair_cycle_number">mzunguko %1$d</string>
     <string name="pair_rename_title">badilisha jina la jozi</string>
     <string name="pair_rename_label">jina</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">kwa saa</string>
     <string name="pair_bought">kilinunuliwa</string>
     <string name="pair_daily_hours_14">saa za kila siku (siku 14)</string>
+    <string name="pair_charge_cycles">mizunguko ya chaji</string>
+    <string name="pair_per_charge">kwa kila chaji</string>
+    <string name="pair_cycles">mizunguko</string>
+    <string name="pair_charge_watched">iliyotazamwa</string>
+    <string name="pair_cycle_number">mzunguko %1$d</string>
     <string name="pair_rename_title">badilisha jina la jozi</string>
     <string name="pair_rename_label">jina</string>
     <string name="pair_retire_title">staafisha jozi hii</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">மணிக்கு</string>
     <string name="pair_bought">வாங்கியது</string>
     <string name="pair_daily_hours_14">தினசரி மணிநேரம் (14 நாட்கள்)</string>
+    <string name="pair_charge_cycles">சார்ஜ் சுழற்சிகள்</string>
+    <string name="pair_per_charge">ஒரு சார்ஜுக்கு</string>
+    <string name="pair_cycles">சுழற்சிகள்</string>
+    <string name="pair_charge_watched">கவனிக்கப்பட்டது</string>
+    <string name="pair_cycle_number">சுழற்சி %1$d</string>
     <string name="pair_rename_title">ஜோடியின் பெயரை மாற்று</string>
     <string name="pair_rename_label">பெயர்</string>
     <string name="pair_retire_title">இந்த ஜோடியை ஓய்வுபெறச் செய்</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ஒரு சார்ஜுக்கு</string>
     <string name="pair_cycles">சுழற்சிகள்</string>
     <string name="pair_charge_watched">கவனிக்கப்பட்டது</string>
+    <string name="pair_vs_new">புதிதாக இருந்தபோதுடன்</string>
     <string name="pair_cycle_number">சுழற்சி %1$d</string>
     <string name="pair_rename_title">ஜோடியின் பெயரை மாற்று</string>
     <string name="pair_rename_label">பெயர்</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">గంటకు</string>
     <string name="pair_bought">కొన్నది</string>
     <string name="pair_daily_hours_14">రోజువారీ గంటలు (14 రోజులు)</string>
+    <string name="pair_charge_cycles">ఛార్జ్ చక్రాలు</string>
+    <string name="pair_per_charge">ఒక్కో ఛార్జ్‌కు</string>
+    <string name="pair_cycles">చక్రాలు</string>
+    <string name="pair_charge_watched">గమనించినది</string>
+    <string name="pair_cycle_number">చక్రం %1$d</string>
     <string name="pair_rename_title">జత పేరు మార్చు</string>
     <string name="pair_rename_label">పేరు</string>
     <string name="pair_retire_title">ఈ జతను విరమింపజేయి</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ఒక్కో ఛార్జ్‌కు</string>
     <string name="pair_cycles">చక్రాలు</string>
     <string name="pair_charge_watched">గమనించినది</string>
+    <string name="pair_vs_new">కొత్తగా ఉన్నప్పటితో</string>
     <string name="pair_cycle_number">చక్రం %1$d</string>
     <string name="pair_rename_title">జత పేరు మార్చు</string>
     <string name="pair_rename_label">పేరు</string>

--- a/app/src/main/res/values-tg/strings.xml
+++ b/app/src/main/res/values-tg/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ба як заряд</string>
     <string name="pair_cycles">давраҳо</string>
     <string name="pair_charge_watched">мушоҳидашуда</string>
+    <string name="pair_vs_new">нисбат ба нав</string>
     <string name="pair_cycle_number">давра %1$d</string>
     <string name="pair_rename_title">номи ҷуфтро иваз кунед</string>
     <string name="pair_rename_label">ном</string>

--- a/app/src/main/res/values-tg/strings.xml
+++ b/app/src/main/res/values-tg/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">дар як соат</string>
     <string name="pair_bought">харида шуда</string>
     <string name="pair_daily_hours_14">соатҳои ҳаррӯза (14 рӯз)</string>
+    <string name="pair_charge_cycles">давраҳои заряд</string>
+    <string name="pair_per_charge">ба як заряд</string>
+    <string name="pair_cycles">давраҳо</string>
+    <string name="pair_charge_watched">мушоҳидашуда</string>
+    <string name="pair_cycle_number">давра %1$d</string>
     <string name="pair_rename_title">номи ҷуфтро иваз кунед</string>
     <string name="pair_rename_label">ном</string>
     <string name="pair_retire_title">ин ҷуфтро ба нафақа бароред</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">ต่อชั่วโมง</string>
     <string name="pair_bought">ซื้อเมื่อ</string>
     <string name="pair_daily_hours_14">ชั่วโมงต่อวัน (14 วัน)</string>
+    <string name="pair_charge_cycles">รอบการชาร์จ</string>
+    <string name="pair_per_charge">ต่อการชาร์จ</string>
+    <string name="pair_cycles">รอบ</string>
+    <string name="pair_charge_watched">ที่สังเกตได้</string>
+    <string name="pair_cycle_number">รอบที่ %1$d</string>
     <string name="pair_rename_title">เปลี่ยนชื่อคู่หูฟัง</string>
     <string name="pair_rename_label">ชื่อ</string>
     <string name="pair_retire_title">เลิกใช้คู่นี้</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">ต่อการชาร์จ</string>
     <string name="pair_cycles">รอบ</string>
     <string name="pair_charge_watched">ที่สังเกตได้</string>
+    <string name="pair_vs_new">เทียบกับตอนใหม่</string>
     <string name="pair_cycle_number">รอบที่ %1$d</string>
     <string name="pair_rename_title">เปลี่ยนชื่อคู่หูฟัง</string>
     <string name="pair_rename_label">ชื่อ</string>

--- a/app/src/main/res/values-ti/strings.xml
+++ b/app/src/main/res/values-ti/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">በብ ምምላእ</string>
     <string name="pair_cycles">ዑደታት</string>
     <string name="pair_charge_watched">ዝተዓዘብናዮ</string>
+    <string name="pair_vs_new">ምስ ሓድሽ ብምንጽጻር</string>
     <string name="pair_cycle_number">ዑደት %1$d</string>
     <string name="pair_rename_title">ሔዱ ስም ዓይነ</string>
     <string name="pair_rename_label">ስም</string>

--- a/app/src/main/res/values-ti/strings.xml
+++ b/app/src/main/res/values-ti/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ሰዓት ብ</string>
     <string name="pair_bought">ይገዘ</string>
     <string name="pair_daily_hours_14">ሕምሳ ሰዓት (14 ሞያ)</string>
+    <string name="pair_charge_cycles">ዑደታት ምምላእ</string>
+    <string name="pair_per_charge">በብ ምምላእ</string>
+    <string name="pair_cycles">ዑደታት</string>
+    <string name="pair_charge_watched">ዝተዓዘብናዮ</string>
+    <string name="pair_cycle_number">ዑደት %1$d</string>
     <string name="pair_rename_title">ሔዱ ስም ዓይነ</string>
     <string name="pair_rename_label">ስም</string>
     <string name="pair_retire_title">ሔዱ ተገዲስ</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">her zarýada</string>
     <string name="pair_cycles">aýlawlar</string>
     <string name="pair_charge_watched">synlanan</string>
+    <string name="pair_vs_new">täze wagtyna görä</string>
     <string name="pair_cycle_number">aýlaw %1$d</string>
     <string name="pair_rename_title">juplanyş ady üýtget</string>
     <string name="pair_rename_label">ady</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">sagat başyna</string>
     <string name="pair_bought">satyn alyndy</string>
     <string name="pair_daily_hours_14">gündelik sagat (14 gün)</string>
+    <string name="pair_charge_cycles">zarýad aýlawlary</string>
+    <string name="pair_per_charge">her zarýada</string>
+    <string name="pair_cycles">aýlawlar</string>
+    <string name="pair_charge_watched">synlanan</string>
+    <string name="pair_cycle_number">aýlaw %1$d</string>
     <string name="pair_rename_title">juplanyş ady üýtget</string>
     <string name="pair_rename_label">ady</string>
     <string name="pair_retire_title">bu juplanyşy pensiýa çykar</string>

--- a/app/src/main/res/values-tn/strings.xml
+++ b/app/src/main/res/values-tn/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ka hora</string>
     <string name="pair_bought">o isiwe</string>
     <string name="pair_daily_hours_14">dithuta tsa letsatsi (matsatsi a 14)</string>
+    <string name="pair_charge_cycles">dipotologo tsa go tjhaja</string>
+    <string name="pair_per_charge">ka tjhaja nngwe</string>
+    <string name="pair_cycles">dipotologo</string>
+    <string name="pair_charge_watched">go lebeletswe</string>
+    <string name="pair_cycle_number">potologo %1$d</string>
     <string name="pair_rename_title">go lesa leina la pabetsa</string>
     <string name="pair_rename_label">leina</string>
     <string name="pair_retire_title">go iketla pabetsa ye</string>

--- a/app/src/main/res/values-tn/strings.xml
+++ b/app/src/main/res/values-tn/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ka tjhaja nngwe</string>
     <string name="pair_cycles">dipotologo</string>
     <string name="pair_charge_watched">go lebeletswe</string>
+    <string name="pair_vs_new">fa e bapisiwa le tse dintjha</string>
     <string name="pair_cycle_number">potologo %1$d</string>
     <string name="pair_rename_title">go lesa leina la pabetsa</string>
     <string name="pair_rename_label">leina</string>

--- a/app/src/main/res/values-to/strings.xml
+++ b/app/src/main/res/values-to/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">mo e hola</string>
     <string name="pair_bought">kuo faʻi</string>
     <string name="pair_daily_hours_14">hola ʻaho (aho 14)</string>
+    <string name="pair_charge_cycles">ngaahi taʻu fakafonu</string>
+    <string name="pair_per_charge">ki he fakafonu taha</string>
+    <string name="pair_cycles">ngaahi taʻu</string>
+    <string name="pair_charge_watched">naʻe sioʻi</string>
+    <string name="pair_cycle_number">taʻu %1$d</string>
     <string name="pair_rename_title">toe hingoa e sipi</string>
     <string name="pair_rename_label">hingoa</string>
     <string name="pair_retire_title">ʻave e sipi ni</string>

--- a/app/src/main/res/values-to/strings.xml
+++ b/app/src/main/res/values-to/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ki he fakafonu taha</string>
     <string name="pair_cycles">ngaahi taʻu</string>
     <string name="pair_charge_watched">naʻe sioʻi</string>
+    <string name="pair_vs_new">fakafehoanaki ki he foʻou</string>
     <string name="pair_cycle_number">taʻu %1$d</string>
     <string name="pair_rename_title">toe hingoa e sipi</string>
     <string name="pair_rename_label">hingoa</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">saat başına</string>
     <string name="pair_bought">satın alındı</string>
     <string name="pair_daily_hours_14">günlük saat (14 gün)</string>
+    <string name="pair_charge_cycles">şarj döngüleri</string>
+    <string name="pair_per_charge">şarj başına</string>
+    <string name="pair_cycles">döngüler</string>
+    <string name="pair_charge_watched">gözlenen</string>
+    <string name="pair_cycle_number">döngü %1$d</string>
     <string name="pair_rename_title">çifti yeniden adlandır</string>
     <string name="pair_rename_label">ad</string>
     <string name="pair_retire_title">bu çifti emekliye ayır</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">şarj başına</string>
     <string name="pair_cycles">döngüler</string>
     <string name="pair_charge_watched">gözlenen</string>
+    <string name="pair_vs_new">yeniyken hâline göre</string>
     <string name="pair_cycle_number">döngü %1$d</string>
     <string name="pair_rename_title">çifti yeniden adlandır</string>
     <string name="pair_rename_label">ad</string>

--- a/app/src/main/res/values-tt/strings.xml
+++ b/app/src/main/res/values-tt/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">сәгать өче</string>
     <string name="pair_bought">сатып алынды</string>
     <string name="pair_daily_hours_14">көннәрбәш сәгать (14 көннәр)</string>
+    <string name="pair_charge_cycles">корылма циклы</string>
+    <string name="pair_per_charge">бер корылмага</string>
+    <string name="pair_cycles">циклар</string>
+    <string name="pair_charge_watched">күзәтелгән</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">зәмегнеңнең исеме үзгәрәрләрен</string>
     <string name="pair_rename_label">исеме</string>
     <string name="pair_retire_title">бу зәмегне пенсияләшмәк</string>

--- a/app/src/main/res/values-tt/strings.xml
+++ b/app/src/main/res/values-tt/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">бер корылмага</string>
     <string name="pair_cycles">циклар</string>
     <string name="pair_charge_watched">күзәтелгән</string>
+    <string name="pair_vs_new">яңа чагы белән чагыштырганда</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">зәмегнеңнең исеме үзгәрәрләрен</string>
     <string name="pair_rename_label">исеме</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">سائات ۈچۈن</string>
     <string name="pair_bought">سېتىۋالغان</string>
     <string name="pair_daily_hours_14">كۈندىلىك سائات (14 كۈن)</string>
+    <string name="pair_charge_cycles">توك قاچىلاش دەۋرىيلىكى</string>
+    <string name="pair_per_charge">ھەر قېتىم توك قاچىلاشقا</string>
+    <string name="pair_cycles">دەۋرىيلىك</string>
+    <string name="pair_charge_watched">كۆزىتىلگەن</string>
+    <string name="pair_cycle_number">دەۋرىيلىك %1$d</string>
     <string name="pair_rename_title">جۈپنىڭ ئاتىنى ئۆزگىرت</string>
     <string name="pair_rename_label">ئات</string>
     <string name="pair_retire_title">بۇ جۈپنى پېنسىيىلاشتۇرۇش</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ھەر قېتىم توك قاچىلاشقا</string>
     <string name="pair_cycles">دەۋرىيلىك</string>
     <string name="pair_charge_watched">كۆزىتىلگەن</string>
+    <string name="pair_vs_new">يېڭى چېغىغا سېلىشتۇرغاندا</string>
     <string name="pair_cycle_number">دەۋرىيلىك %1$d</string>
     <string name="pair_rename_title">جۈپنىڭ ئاتىنى ئۆزگىرت</string>
     <string name="pair_rename_label">ئات</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">на один заряд</string>
     <string name="pair_cycles">цикли</string>
     <string name="pair_charge_watched">під наглядом</string>
+    <string name="pair_vs_new">порівняно з новими</string>
     <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">перейменувати пару</string>
     <string name="pair_rename_label">назва</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">за годину</string>
     <string name="pair_bought">куплено</string>
     <string name="pair_daily_hours_14">години на день (14 днів)</string>
+    <string name="pair_charge_cycles">цикли заряджання</string>
+    <string name="pair_per_charge">на один заряд</string>
+    <string name="pair_cycles">цикли</string>
+    <string name="pair_charge_watched">під наглядом</string>
+    <string name="pair_cycle_number">цикл %1$d</string>
     <string name="pair_rename_title">перейменувати пару</string>
     <string name="pair_rename_label">назва</string>
     <string name="pair_retire_title">списати цю пару</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">فی چارج</string>
     <string name="pair_cycles">سائیکل</string>
     <string name="pair_charge_watched">مشاہدہ شدہ</string>
+    <string name="pair_vs_new">نئے کے مقابلے میں</string>
     <string name="pair_cycle_number">سائیکل %1$d</string>
     <string name="pair_rename_title">جوڑی کا نام تبدیل کریں</string>
     <string name="pair_rename_label">نام</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">فی گھنٹہ</string>
     <string name="pair_bought">خریدی گئی</string>
     <string name="pair_daily_hours_14">روزانہ کے گھنٹے (14 دن)</string>
+    <string name="pair_charge_cycles">چارج سائیکل</string>
+    <string name="pair_per_charge">فی چارج</string>
+    <string name="pair_cycles">سائیکل</string>
+    <string name="pair_charge_watched">مشاہدہ شدہ</string>
+    <string name="pair_cycle_number">سائیکل %1$d</string>
     <string name="pair_rename_title">جوڑی کا نام تبدیل کریں</string>
     <string name="pair_rename_label">نام</string>
     <string name="pair_retire_title">اس جوڑی کو ریٹائر کریں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_per_charge">mỗi lần sạc</string>
     <string name="pair_cycles">chu kỳ</string>
     <string name="pair_charge_watched">đã quan sát</string>
+    <string name="pair_vs_new">so với lúc mới</string>
     <string name="pair_cycle_number">chu kỳ %1$d</string>
     <string name="pair_rename_title">đổi tên đôi tai nghe</string>
     <string name="pair_rename_label">tên</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -98,6 +98,11 @@
     <string name="pair_per_hour">mỗi giờ</string>
     <string name="pair_bought">đã mua</string>
     <string name="pair_daily_hours_14">số giờ mỗi ngày (14 ngày)</string>
+    <string name="pair_charge_cycles">chu kỳ sạc</string>
+    <string name="pair_per_charge">mỗi lần sạc</string>
+    <string name="pair_cycles">chu kỳ</string>
+    <string name="pair_charge_watched">đã quan sát</string>
+    <string name="pair_cycle_number">chu kỳ %1$d</string>
     <string name="pair_rename_title">đổi tên đôi tai nghe</string>
     <string name="pair_rename_label">tên</string>
     <string name="pair_retire_title">cho đôi này nghỉ hưu</string>

--- a/app/src/main/res/values-wo/strings.xml
+++ b/app/src/main/res/values-wo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ci sarse bu nekk</string>
     <string name="pair_cycles">wërndal</string>
     <string name="pair_charge_watched">gis nañu ko</string>
+    <string name="pair_vs_new">bu ñu ko méngaleek bu bees</string>
     <string name="pair_cycle_number">wërndal %1$d</string>
     <string name="pair_rename_title">sikasiit bi may ci seriñ</string>
     <string name="pair_rename_label">seriñ</string>

--- a/app/src/main/res/values-wo/strings.xml
+++ b/app/src/main/res/values-wo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">jàngal bu</string>
     <string name="pair_bought">aget</string>
     <string name="pair_daily_hours_14">jàngal bu sum (14 sukkandé)</string>
+    <string name="pair_charge_cycles">wërndalu sarse</string>
+    <string name="pair_per_charge">ci sarse bu nekk</string>
+    <string name="pair_cycles">wërndal</string>
+    <string name="pair_charge_watched">gis nañu ko</string>
+    <string name="pair_cycle_number">wërndal %1$d</string>
     <string name="pair_rename_title">sikasiit bi may ci seriñ</string>
     <string name="pair_rename_label">seriñ</string>
     <string name="pair_retire_title">sikasiit bi sikasiit jëm</string>

--- a/app/src/main/res/values-xh/strings.xml
+++ b/app/src/main/res/values-xh/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">nge-yure</string>
     <string name="pair_bought">kwathengwa</string>
     <string name="pair_daily_hours_14">iiyure zosuku (amashumi-amathandathu emali)</string>
+    <string name="pair_charge_cycles">imijikelo yokutshaja</string>
+    <string name="pair_per_charge">ngokutshaja okunye</string>
+    <string name="pair_cycles">imijikelo</string>
+    <string name="pair_charge_watched">okubonwayo</string>
+    <string name="pair_cycle_number">umjikelo %1$d</string>
     <string name="pair_rename_title">biza le milambo kwakhona</string>
     <string name="pair_rename_label">igama</string>
     <string name="pair_retire_title">igqitshile ezi milambo</string>

--- a/app/src/main/res/values-xh/strings.xml
+++ b/app/src/main/res/values-xh/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ngokutshaja okunye</string>
     <string name="pair_cycles">imijikelo</string>
     <string name="pair_charge_watched">okubonwayo</string>
+    <string name="pair_vs_new">xa kuthelekiswa nezintsha</string>
     <string name="pair_cycle_number">umjikelo %1$d</string>
     <string name="pair_rename_title">biza le milambo kwakhona</string>
     <string name="pair_rename_label">igama</string>

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">fún gbígbà agbára kan</string>
     <string name="pair_cycles">àyíká</string>
     <string name="pair_charge_watched">tí a wò</string>
+    <string name="pair_vs_new">ní ìfiwéra sí tuntun</string>
     <string name="pair_cycle_number">àyíká %1$d</string>
     <string name="pair_rename_title">tun akawe alalade</string>
     <string name="pair_rename_label">oruko</string>

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ni logun kan</string>
     <string name="pair_bought">rira</string>
     <string name="pair_daily_hours_14">logun owurọ (14 ojo)</string>
+    <string name="pair_charge_cycles">àyíká gbígbà agbára</string>
+    <string name="pair_per_charge">fún gbígbà agbára kan</string>
+    <string name="pair_cycles">àyíká</string>
+    <string name="pair_charge_watched">tí a wò</string>
+    <string name="pair_cycle_number">àyíká %1$d</string>
     <string name="pair_rename_title">tun akawe alalade</string>
     <string name="pair_rename_label">oruko</string>
     <string name="pair_retire_title">tẹ alalade yii</string>

--- a/app/src/main/res/values-za/strings.xml
+++ b/app/src/main/res/values-za/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">gunz by haeq</string>
     <string name="pair_bought">gvuq</string>
     <string name="pair_daily_hours_14">gunz ndieq (14 ndieq)</string>
+    <string name="pair_charge_cycles">cungdenh couhgeiz</string>
+    <string name="pair_per_charge">moix baez cungdenh</string>
+    <string name="pair_cycles">couhgeiz</string>
+    <string name="pair_charge_watched">gozcaz gvaq</string>
+    <string name="pair_cycle_number">couhgeiz %1$d</string>
     <string name="pair_rename_title">seungj haeq ndungz</string>
     <string name="pair_rename_label">haeq</string>
     <string name="pair_retire_title">youq ndungz yien</string>

--- a/app/src/main/res/values-za/strings.xml
+++ b/app/src/main/res/values-za/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">moix baez cungdenh</string>
     <string name="pair_cycles">couhgeiz</string>
     <string name="pair_charge_watched">gozcaz gvaq</string>
+    <string name="pair_vs_new">doiq moq seiz</string>
     <string name="pair_cycle_number">couhgeiz %1$d</string>
     <string name="pair_rename_title">seungj haeq ndungz</string>
     <string name="pair_rename_label">haeq</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -91,6 +91,11 @@
     <string name="pair_per_hour">ngehora</string>
     <string name="pair_bought">kuthengiwe</string>
     <string name="pair_daily_hours_14">amahora ansuku zonke (izinsuku ezingu-14)</string>
+    <string name="pair_charge_cycles">imijikelezo yokushaja</string>
+    <string name="pair_per_charge">ngokushaja okukodwa</string>
+    <string name="pair_cycles">imijikelezo</string>
+    <string name="pair_charge_watched">okubukiwe</string>
+    <string name="pair_cycle_number">umjikelezo %1$d</string>
     <string name="pair_rename_title">qamba kabusha ipheya</string>
     <string name="pair_rename_label">igama</string>
     <string name="pair_retire_title">thatha umhlalaphansi kuleli pheya</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -95,6 +95,7 @@
     <string name="pair_per_charge">ngokushaja okukodwa</string>
     <string name="pair_cycles">imijikelezo</string>
     <string name="pair_charge_watched">okubukiwe</string>
+    <string name="pair_vs_new">uma kuqhathaniswa nezintsha</string>
     <string name="pair_cycle_number">umjikelezo %1$d</string>
     <string name="pair_rename_title">qamba kabusha ipheya</string>
     <string name="pair_rename_label">igama</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,15 @@
     <string name="pair_per_hour">per hour</string>
     <string name="pair_bought">bought</string>
     <string name="pair_daily_hours_14">daily hours (14 days)</string>
+    <!-- Titles the charge-cycle chart and the cycles listed under it. A cycle is 100% of battery
+         used, however many part-charges that took. -->
+    <string name="pair_charge_cycles">charge cycles</string>
+    <string name="pair_per_charge">per charge</string>
+    <string name="pair_cycles">cycles</string>
+    <!-- The listening time the "per charge" figure is worked out from. -->
+    <string name="pair_charge_watched">watched</string>
+    <!-- Names one cycle in the list and on the chart's axis: "cycle 1", "cycle 12". -->
+    <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">rename pair</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">retire this pair</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
     <string name="pair_cycles">cycles</string>
     <!-- The listening time the "per charge" figure is worked out from. -->
     <string name="pair_charge_watched">watched</string>
+    <!-- Labels a percentage: what a charge buys now against what it bought when the pair was new. -->
+    <string name="pair_vs_new">vs when new</string>
     <!-- Names one cycle in the list and on the chart's axis: "cycle 1", "cycle 12". -->
     <string name="pair_cycle_number">cycle %1$d</string>
     <string name="pair_rename_title">rename pair</string>

--- a/app/src/test/java/it/eldavo/ylih/data/SessionRepositoryTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/data/SessionRepositoryTest.kt
@@ -600,5 +600,14 @@ class SessionRepositoryTest {
             listOf(90, 60),
             repository.observeBatterySamples(pairId).first().map { it.level },
         )
+        // `pairId` is carried on the reading as well as reachable through its session, so that the
+        // read above never joins `sessions` — see BatterySampleEntity. The two must agree.
+        for (sample in batterySamples()) {
+            assertEquals(
+                "a reading's pair must be its session's pair",
+                db.sessionDao().getAll().single { it.id == sample.sessionId }.pairId,
+                sample.pairId,
+            )
+        }
     }
 }

--- a/app/src/test/java/it/eldavo/ylih/data/SessionRepositoryTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/data/SessionRepositoryTest.kt
@@ -2,6 +2,12 @@ package it.eldavo.ylih.data
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import it.eldavo.ylih.tracking.BtBatteryReceiver
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -417,5 +423,182 @@ class SessionRepositoryTest {
         assertEquals(1, db.deviceDao().getAll().size)
         assertEquals("WH-1000XM5", db.deviceDao().findByKey(buds.key)!!.defaultName)
         assertEquals(1, db.pairDao().getAll().size)
+    }
+
+    private suspend fun batterySamples() = db.batterySampleDao().getAll()
+
+    @Test
+    fun `a battery reading is filed against the session that was open when it arrived`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + hour)
+
+        val sample = batterySamples().single()
+        assertEquals(sessions().single().id, sample.sessionId)
+        assertEquals(80, sample.level)
+        assertEquals(clockNow + hour, sample.at)
+    }
+
+    /**
+     * With no session there is nothing to file against, and a reading that outlived its session
+     * would let two of them be subtracted across a gap nothing watched.
+     */
+    /**
+     * The `false` is the contract the receiver's retry is built on: it means "ask again", because
+     * the first reading of a session routinely arrives before the session itself does.
+     */
+    @Test
+    fun `a battery reading with no session open is refused and says so`() = runTest {
+        assertEquals(
+            "no device at all",
+            false,
+            repository.recordBatteryLevel(buds.key, level = 80, at = clockNow),
+        )
+        assertTrue("nothing to attach it to", batterySamples().isEmpty())
+
+        repository.onConnected(buds, at = clockNow)
+        repository.onDisconnected(buds.key, at = clockNow + hour)
+        assertEquals(
+            "a closed session is not one to file against either",
+            false,
+            repository.recordBatteryLevel(buds.key, level = 60, at = clockNow + 2 * hour),
+        )
+
+        assertTrue(batterySamples().isEmpty())
+    }
+
+    /**
+     * The stack re-announces the level it already reported when another source of it appears. A
+     * second row would put a segment of no drain in the middle of a discharge.
+     */
+    @Test
+    fun `the same level reported twice is recorded once`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + hour)
+        assertEquals(
+            "a duplicate is still an answer, so the caller must not ask again",
+            true,
+            repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + 2 * hour),
+        )
+
+        assertEquals(1, batterySamples().size)
+
+        repository.recordBatteryLevel(buds.key, level = 70, at = clockNow + 3 * hour)
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + 4 * hour)
+
+        assertEquals(
+            "but a level that comes back after changing is a real reading",
+            listOf(80, 70, 80),
+            batterySamples().map { it.level },
+        )
+    }
+
+    /**
+     * -1 is "unknown" and -100 is "Bluetooth is off", and the first of those is broadcast on every
+     * disconnect. Stored at face value that is a drop of the whole battery into nothing.
+     */
+    @Test
+    fun `a level outside a percentage is not a reading`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = -1, at = clockNow + hour)
+        repository.recordBatteryLevel(buds.key, level = -100, at = clockNow + 2 * hour)
+        repository.recordBatteryLevel(buds.key, level = 101, at = clockNow + 3 * hour)
+
+        assertTrue(batterySamples().isEmpty())
+
+        repository.recordBatteryLevel(buds.key, level = 0, at = clockNow + 4 * hour)
+        repository.recordBatteryLevel(buds.key, level = 100, at = clockNow + 5 * hour)
+
+        assertEquals("but both ends of the range are", listOf(0, 100), batterySamples().map { it.level })
+    }
+
+    @Test
+    fun `a reading for a device the user ignores is dropped with its session`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        val deviceId = db.deviceDao().findByKey(buds.key)!!.id
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + hour)
+
+        repository.setDeviceIgnored(deviceId, ignored = true)
+        repository.recordBatteryLevel(buds.key, level = 70, at = clockNow + 2 * hour)
+
+        assertEquals("ignoring closes the session, so nothing takes the next reading", 1, batterySamples().size)
+    }
+
+    @Test
+    fun `deleting a session takes its readings with it`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + hour)
+        val sessionId = sessions().single().id
+
+        repository.deleteSession(sessionId)
+
+        assertTrue(batterySamples().isEmpty())
+    }
+
+    @Test
+    fun `deleting a pair takes its readings with it`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = 80, at = clockNow + hour)
+
+        repository.deletePair(db.pairDao().getAll().single().id)
+
+        assertTrue(batterySamples().isEmpty())
+    }
+
+    /**
+     * The retry [BtBatteryReceiver] wraps every reading in, driven in virtual time.
+     *
+     * On a phone this is the ordinary case rather than a rare one: the battery broadcast arrives
+     * about 400 ms after ACL_CONNECTED and beat the app's own session row by 68 ms when it was
+     * measured. Many headsets report their battery only at connect, so a reading dropped here is
+     * that pair's charge cycles gone entirely.
+     *
+     * `runTest` makes `delay` virtual, so this pins the behaviour rather than the wall clock — the
+     * same test written against the real two seconds was flaky under a loaded suite. Driving that
+     * clock by hand is what needs the opt-in.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `a reading that arrives before its session is retried and lands`() = runTest {
+        val job = launch {
+            BtBatteryReceiver.recordWithRetry(repository, buds.key, level = 70, at = clockNow)
+        }
+
+        advanceTimeBy(1_000)
+        runCurrent()
+        assertTrue("still waiting for the connect to be written", batterySamples().isEmpty())
+
+        repository.onConnected(buds, at = clockNow)
+        advanceTimeBy(2_000)
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(70), batterySamples().map { it.level })
+        assertEquals(sessions().single().id, batterySamples().single().sessionId)
+    }
+
+    @Test
+    fun `a reading with no session even after the retry is dropped`() = runTest {
+        BtBatteryReceiver.recordWithRetry(repository, buds.key, level = 70, at = clockNow)
+
+        assertTrue("nothing ever connected, so there is nothing to file it against", batterySamples().isEmpty())
+    }
+
+    @Test
+    fun `a pair's readings are observed across every session it has had`() = runTest {
+        repository.onConnected(buds, at = clockNow)
+        repository.recordBatteryLevel(buds.key, level = 90, at = clockNow + hour)
+        repository.onDisconnected(buds.key, at = clockNow + 2 * hour)
+        repository.onConnected(buds, at = clockNow + 3 * hour)
+        repository.recordBatteryLevel(buds.key, level = 60, at = clockNow + 4 * hour)
+
+        // A second pair's readings must not leak into the first one's charge cycles.
+        repository.onConnected(wired, at = clockNow)
+        repository.recordBatteryLevel(wired.key, level = 50, at = clockNow + hour)
+
+        val pairId = db.pairDao().activeFor(db.deviceDao().findByKey(buds.key)!!.id)!!.id
+        assertEquals(
+            listOf(90, 60),
+            repository.observeBatterySamples(pairId).first().map { it.level },
+        )
     }
 }

--- a/app/src/test/java/it/eldavo/ylih/data/YlihDatabaseMigrationTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/data/YlihDatabaseMigrationTest.kt
@@ -166,6 +166,48 @@ class YlihDatabaseMigrationTest {
     }
 
     /**
+     * The newest migration's table, written to rather than merely validated.
+     *
+     * Room's identity check compares columns and indices; it says nothing about whether the foreign
+     * key really cascades, and the cascade is what keeps a deleted session from leaving readings
+     * behind that the next pair's charge cycles would subtract across.
+     */
+    @Test
+    fun `an upgraded install can record a battery level`() {
+        writeVersion1Database {
+            execSQL(
+                "INSERT INTO devices (id, deviceKey, kind, defaultName, firstSeenAt, ignored) " +
+                    "VALUES (1, '5E:C2', 'BLUETOOTH', 'WH-1000XM4', 1000, 0)",
+            )
+            execSQL(
+                "INSERT INTO pairs (id, deviceId, label, generation, startedAt) " +
+                    "VALUES (1, 1, 'the good ones', 1, 1000)",
+            )
+            execSQL(
+                "INSERT INTO sessions (id, pairId, connectedAt, heartbeatAt) " +
+                    "VALUES (1, 1, 1000, 1000)",
+            )
+        }
+
+        val db = openMigrated()
+        try {
+            runBlocking {
+                SessionRepository(db) { 4000L }.recordBatteryLevel("5E:C2", level = 80)
+
+                assertEquals(80, db.batterySampleDao().getAll().single().level)
+
+                db.sessionDao().delete(1)
+                assertTrue(
+                    "readings do not outlive the session they were taken in",
+                    db.batterySampleDao().getAll().isEmpty(),
+                )
+            }
+        } finally {
+            db.close()
+        }
+    }
+
+    /**
      * The guard on the guard: the fixture below is written by hand, and a hand-written fixture is
      * a thing that can quietly stop resembling what version 1 shipped. Checked against the
      * committed `1.json` rather than against itself, because a fixture that agrees only with its
@@ -212,9 +254,10 @@ class YlihDatabaseMigrationTest {
                 assertTrue(it.moveToFirst())
                 assertEquals(VERSION_1_IDENTITY_HASH, it.getString(0))
             }
-            // The table the migration adds must not be there yet, or nothing above is a migration.
+            // The tables the migrations add must not be there yet, or nothing above is a migration.
             db.rawQuery(
-                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'settings'",
+                "SELECT name FROM sqlite_master WHERE type = 'table' " +
+                    "AND name IN ('settings', 'battery_samples')",
                 null,
             ).use { assertEquals(0, it.count) }
         }

--- a/app/src/test/java/it/eldavo/ylih/export/JsonBackupTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/export/JsonBackupTest.kt
@@ -109,10 +109,10 @@ class JsonBackupTest {
         // Charge cycles are worked out from these and from nothing else, so a backup that drops
         // them restores a pair whose battery history starts again from today.
         target.batterySampleDao().insert(
-            BatterySampleEntity(sessionId = openId, at = now - hour, level = 90),
+            BatterySampleEntity(sessionId = openId, pairId = pairId, at = now - hour, level = 90),
         )
         target.batterySampleDao().insert(
-            BatterySampleEntity(sessionId = openId, at = now, level = 80),
+            BatterySampleEntity(sessionId = openId, pairId = pairId, at = now, level = 80),
         )
     }
 

--- a/app/src/test/java/it/eldavo/ylih/export/JsonBackupTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/export/JsonBackupTest.kt
@@ -3,6 +3,7 @@ package it.eldavo.ylih.export
 import android.os.Build
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import it.eldavo.ylih.data.BatterySampleEntity
 import it.eldavo.ylih.data.DeviceEntity
 import it.eldavo.ylih.data.DeviceKind
 import it.eldavo.ylih.data.EndReason
@@ -95,7 +96,7 @@ class JsonBackupTest {
             ),
         )
         // Still open, never measured — the two nullable columns that a lossy format would drop.
-        target.sessionDao().insert(
+        val openId = target.sessionDao().insert(
             SessionEntity(
                 pairId = pairId,
                 connectedAt = now - hour,
@@ -104,6 +105,14 @@ class JsonBackupTest {
                 heartbeatAt = now,
                 endReason = null,
             ),
+        )
+        // Charge cycles are worked out from these and from nothing else, so a backup that drops
+        // them restores a pair whose battery history starts again from today.
+        target.batterySampleDao().insert(
+            BatterySampleEntity(sessionId = openId, at = now - hour, level = 90),
+        )
+        target.batterySampleDao().insert(
+            BatterySampleEntity(sessionId = openId, at = now, level = 80),
         )
     }
 
@@ -155,6 +164,12 @@ class JsonBackupTest {
         assertEquals(listOf("DISCONNECTED", null), backup.sessions.map { it.endReason })
         assertEquals(listOf(90 * 60_000L, null), backup.sessions.map { it.playingMs })
         assertEquals(listOf(now - 28 * hour, null), backup.sessions.map { it.disconnectedAt })
+        assertEquals(listOf(90, 80), backup.batterySamples.map { it.level })
+        assertEquals(
+            "a reading names the session it was taken in, and that is the whole rule it obeys",
+            listOf(backup.sessions.last().id, backup.sessions.last().id),
+            backup.batterySamples.map { it.sessionId },
+        )
     }
 
     @Test
@@ -169,6 +184,30 @@ class JsonBackupTest {
             assertEquals(db.deviceDao().getAll(), restored.deviceDao().getAll())
             assertEquals(db.pairDao().getAll(), restored.pairDao().getAll())
             assertEquals(db.sessionDao().getAll(), restored.sessionDao().getAll())
+            assertEquals(db.batterySampleDao().getAll(), restored.batterySampleDao().getAll())
+        } finally {
+            restored.close()
+        }
+    }
+
+    /**
+     * The field arrived with a default rather than a format bump, exactly as `settings` did, so a
+     * file written by the build before charge cycles existed still restores its history — it simply
+     * has no readings in it.
+     */
+    @Test
+    fun `a backup written before battery readings existed still imports`() = runTest {
+        seed(db)
+        val payload = JsonBackup.export(db, now)
+        val withoutReadings = json.decodeFromString<JsonBackup.Backup>(payload)
+            .let { Json.encodeToString(it.copy(batterySamples = emptyList())) }
+
+        val restored = newDatabase()
+        try {
+            assertEquals(2, JsonBackup.import(restored, withoutReadings))
+
+            assertEquals(db.sessionDao().getAll(), restored.sessionDao().getAll())
+            assertTrue(restored.batterySampleDao().getAll().isEmpty())
         } finally {
             restored.close()
         }

--- a/app/src/test/java/it/eldavo/ylih/stats/ChargeTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/stats/ChargeTest.kt
@@ -1,0 +1,258 @@
+package it.eldavo.ylih.stats
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A charge cycle is a hundred percentage points used, and the hours it bought are what say whether
+ * the battery is getting worse. Both halves of that ratio have to come from the same stretches of
+ * time or the figure means nothing, which is what most of this file is about.
+ */
+class ChargeTest {
+
+    private val hour = 3_600_000L
+    private val start = 1_700_000_000_000L
+
+    private fun reading(sessionId: Long, hoursIn: Long, level: Int) =
+        Reading(sessionId, start + hoursIn * hour, level)
+
+    /** A closed session running [hours] hours from [fromHour], playing for [playing] of them. */
+    private fun span(fromHour: Long, hours: Long, playing: Long? = null) = Span(
+        startAt = start + fromHour * hour,
+        endAt = start + (fromHour + hours) * hour,
+        playingMs = playing?.times(hour),
+    )
+
+    private fun summarize(
+        readings: List<Reading>,
+        spans: Map<Long, Span> = mapOf(1L to span(0, 24)),
+        counting: Counting = Counting.CONNECTED,
+    ) = Charge.summarize(readings, spans, now = start + 48 * hour, counting = counting)
+
+    @Test
+    fun `a drop between two readings is drain, and the time between them bought it`() {
+        val summary = summarize(
+            listOf(reading(1, 0, 80), reading(1, 2, 60)),
+        )
+
+        assertEquals(20, summary.pointsDrained)
+        assertEquals(2 * hour, summary.countedMs)
+        // Twenty points bought two hours, so a hundred would buy ten.
+        assertEquals(10 * hour, summary.msPerCycle)
+        assertEquals(0.2, summary.cyclesFraction, 0.0001)
+        assertTrue(summary.hasData)
+    }
+
+    @Test
+    fun `a level going up is a charge and counts for nothing`() {
+        val summary = summarize(
+            listOf(reading(1, 0, 40), reading(1, 1, 90), reading(1, 3, 80)),
+        )
+
+        // Only the 90 → 80 leg is drain; the 40 → 90 in between is the headset being charged.
+        assertEquals(10, summary.pointsDrained)
+        assertEquals(2 * hour, summary.countedMs)
+    }
+
+    /**
+     * The rule the whole file rests on. Between these two readings the headphones were off the
+     * phone: nobody knows whether they were charged in that gap, and there is certainly no
+     * listening to credit it with.
+     */
+    @Test
+    fun `a drop across a session boundary is not drain`() {
+        val summary = summarize(
+            listOf(reading(1, 0, 90), reading(1, 1, 80), reading(2, 20, 30), reading(2, 21, 20)),
+            spans = mapOf(1L to span(0, 2), 2L to span(20, 2)),
+        )
+
+        // 90 → 80 and 30 → 20, and nothing for the 80 → 30 between the two sessions.
+        assertEquals(20, summary.pointsDrained)
+        assertEquals(2 * hour, summary.countedMs)
+    }
+
+    @Test
+    fun `a hundred points is one cycle whatever it took to get there`() {
+        // Five evenings of twenty points each, an hour apiece.
+        val readings = (0L until 5L).flatMap {
+            listOf(reading(it + 1, it * 5, 100), reading(it + 1, it * 5 + 1, 80))
+        }
+        val spans = (0L until 5L).associate { (it + 1) to span(it * 5, 2) }
+
+        val summary = Charge.summarize(readings, spans, now = start + 48 * hour)
+
+        assertEquals(100, summary.pointsDrained)
+        assertEquals(1, summary.cycles.size)
+        assertEquals(5 * hour, summary.cycles.single().countedMs)
+        assertEquals(0, summary.partialPoints)
+    }
+
+    @Test
+    fun `a cycle boundary inside one segment splits both the points and the hours`() {
+        val summary = summarize(
+            // Sixty points over six hours, then eighty more over eight: the second segment
+            // straddles the hundred.
+            listOf(
+                reading(1, 0, 100), reading(1, 6, 40),
+                reading(2, 20, 100), reading(2, 28, 20),
+            ),
+            spans = mapOf(1L to span(0, 7), 2L to span(20, 9)),
+        )
+
+        assertEquals(140, summary.pointsDrained)
+        assertEquals(1, summary.cycles.size)
+        // Forty of the second segment's eighty points complete the first cycle, so half its eight
+        // hours goes with them: six plus four.
+        assertEquals(10 * hour, summary.cycles.single().countedMs)
+        assertEquals(start, summary.cycles.single().startAt)
+        // And half its eight hours of wall clock too, so the cycle ends four hours into it.
+        assertEquals(start + 24 * hour, summary.cycles.single().endAt)
+        // The remainder is the cycle still in progress, not a second completed one.
+        assertEquals(40, summary.partialPoints)
+        assertEquals(14 * hour, summary.countedMs)
+    }
+
+    @Test
+    fun `a segment of a hundred points on its own completes a cycle`() {
+        // A headset that reports at full and then not again until it is flat.
+        val summary = summarize(listOf(reading(1, 0, 100), reading(1, 7, 0)))
+
+        assertEquals(1, summary.cycles.size)
+        assertEquals(7 * hour, summary.cycles.single().countedMs)
+        assertEquals(0, summary.partialPoints)
+        assertEquals(7 * hour, summary.msPerCycle)
+    }
+
+    @Test
+    fun `counting playback credits a segment its share of the session's playing time`() {
+        val summary = summarize(
+            listOf(reading(1, 0, 90), reading(1, 2, 70)),
+            // A ten-hour session with five hours of audio in it: half the time was listening.
+            spans = mapOf(1L to span(0, 10, playing = 5)),
+            counting = Counting.PLAYBACK,
+        )
+
+        assertEquals(20, summary.pointsDrained)
+        assertEquals(hour, summary.countedMs)
+        assertEquals(5 * hour, summary.msPerCycle)
+    }
+
+    /**
+     * A session recorded in Bluetooth-only mode has no playback figure at all. Crediting it zero
+     * would read as a charge that gave nothing back, so its drain leaves the denominator too — the
+     * same choice `Stats.counted` makes.
+     */
+    @Test
+    fun `counting playback drops a session that never measured it`() {
+        val readings = listOf(
+            reading(1, 0, 90), reading(1, 2, 70),
+            reading(2, 20, 60), reading(2, 22, 40),
+        )
+        val spans = mapOf(1L to span(0, 10, playing = 5), 2L to span(20, 10))
+
+        val connected = Charge.summarize(readings, spans, now = start + 48 * hour)
+        val playback =
+            Charge.summarize(readings, spans, now = start + 48 * hour, counting = Counting.PLAYBACK)
+
+        assertEquals(40, connected.pointsDrained)
+        assertEquals(20, playback.pointsDrained)
+    }
+
+    @Test
+    fun `an open session's playback share is measured against how long it has been running`() {
+        val readings = listOf(reading(1, 0, 90), reading(1, 2, 70))
+        val open = Span(startAt = start, endAt = null, playingMs = 2 * hour)
+
+        // Four hours in, half of them playing: the two-hour segment is worth one hour.
+        val summary = Charge.summarize(
+            readings,
+            mapOf(1L to open),
+            now = start + 4 * hour,
+            counting = Counting.PLAYBACK,
+        )
+
+        assertEquals(hour, summary.countedMs)
+    }
+
+    @Test
+    fun `no readings is no answer rather than a zero`() {
+        val summary = summarize(emptyList())
+
+        assertFalse(summary.hasData)
+        assertEquals(0, summary.pointsDrained)
+        assertEquals(0L, summary.msPerCycle)
+        assertTrue(summary.cycles.isEmpty())
+    }
+
+    @Test
+    fun `one reading on its own says nothing`() {
+        val summary = summarize(listOf(reading(1, 0, 100)))
+
+        assertFalse(summary.hasData)
+    }
+
+    @Test
+    fun `a repeated level is drain of nothing and is ignored`() {
+        val summary = summarize(
+            listOf(reading(1, 0, 70), reading(1, 1, 70), reading(1, 2, 60)),
+        )
+
+        assertEquals(10, summary.pointsDrained)
+        assertEquals(hour, summary.countedMs)
+    }
+
+    /**
+     * A clock corrected backwards mid-session leaves a reading dated before the one it followed.
+     * The drain is real, but there is no stretch of time to credit it to, so neither side takes it
+     * — the alternative is a negative number of hours dragging the whole ratio down.
+     */
+    @Test
+    fun `a backwards clock step is dropped from both sides`() {
+        val summary = summarize(
+            listOf(Reading(1, start + 2 * hour, 80), Reading(1, start + hour, 60)),
+        )
+
+        assertFalse(summary.hasData)
+        assertEquals(0L, summary.countedMs)
+    }
+
+    @Test
+    fun `readings arriving out of order are put back in order first`() {
+        val summary = summarize(
+            listOf(reading(1, 2, 60), reading(1, 0, 80), reading(1, 1, 70)),
+        )
+
+        assertEquals(20, summary.pointsDrained)
+        assertEquals(2 * hour, summary.countedMs)
+    }
+
+    @Test
+    fun `cycles come back oldest first, so a failing battery reads as a fall`() {
+        // Two full cycles: the first bought ten hours, the second only six.
+        val readings = listOf(
+            reading(1, 0, 100), reading(1, 10, 0),
+            reading(2, 20, 100), reading(2, 26, 0),
+        )
+        val spans = mapOf(1L to span(0, 11), 2L to span(20, 7))
+
+        val summary = Charge.summarize(readings, spans, now = start + 48 * hour)
+
+        assertEquals(listOf(10 * hour, 6 * hour), summary.cycles.map { it.countedMs })
+        assertEquals(8 * hour, summary.msPerCycle)
+    }
+
+    @Test
+    fun `a session with no span at all still counts its connected time`() {
+        // Belt and braces: nothing deletes a session out from under its readings, but the maths
+        // must not silently drop drain if something ever does.
+        val summary = summarize(
+            listOf(reading(7, 0, 80), reading(7, 1, 70)),
+            spans = emptyMap(),
+        )
+
+        assertEquals(10, summary.pointsDrained)
+        assertEquals(hour, summary.countedMs)
+    }
+}

--- a/app/src/test/java/it/eldavo/ylih/stats/ChargeTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/stats/ChargeTest.kt
@@ -2,6 +2,7 @@ package it.eldavo.ylih.stats
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -241,6 +242,69 @@ class ChargeTest {
 
         assertEquals(listOf(10 * hour, 6 * hour), summary.cycles.map { it.countedMs })
         assertEquals(8 * hour, summary.msPerCycle)
+    }
+
+    /** [hours] one per cycle, each drained in a session of its own. */
+    private fun cyclesOf(vararg hours: Double): ChargeSummary {
+        val readings = mutableListOf<Reading>()
+        val spans = mutableMapOf<Long, Span>()
+        var at = start
+        hours.forEachIndexed { i, h ->
+            val id = (i + 1).toLong()
+            val length = (h * hour).toLong()
+            spans[id] = Span(at, at + length, null)
+            readings += Reading(id, at, 100)
+            readings += Reading(id, at + length, 0)
+            at += length + 24 * hour
+        }
+        return Charge.summarize(readings, spans, now = at)
+    }
+
+    @Test
+    fun `a battery that has halved reports half of what it managed when new`() {
+        val summary = cyclesOf(10.0, 5.0)
+
+        assertEquals(2, summary.cycles.size)
+        assertEquals(1, summary.comparisonWindow)
+        assertEquals(0.5, summary.versusNew!!, 0.0001)
+    }
+
+    /**
+     * The reason this is not the literal last cycle over the literal first: one unlucky pair of
+     * cycles would say the battery had collapsed, when averaging both ends says it has barely
+     * moved. Eight cycles average two at each end.
+     */
+    @Test
+    fun `both ends are averaged, so one odd cycle does not decide the figure`() {
+        val steady = cyclesOf(10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 4.0)
+
+        assertEquals(2, steady.comparisonWindow)
+        // (10 + 4) / 2 against (10 + 10) / 2 — not 4 against 10.
+        assertEquals(0.7, steady.versusNew!!, 0.0001)
+    }
+
+    @Test
+    fun `the window grows with the history but stops at five`() {
+        assertEquals(1, cyclesOf(*DoubleArray(4) { 8.0 }).comparisonWindow)
+        assertEquals(2, cyclesOf(*DoubleArray(8) { 8.0 }).comparisonWindow)
+        assertEquals(5, cyclesOf(*DoubleArray(20) { 8.0 }).comparisonWindow)
+        assertEquals(
+            "and never so far that the two ends could overlap",
+            MAX_COMPARISON_CYCLES,
+            cyclesOf(*DoubleArray(60) { 8.0 }).comparisonWindow,
+        )
+    }
+
+    @Test
+    fun `one cycle cannot be compared with anything`() {
+        assertNull(cyclesOf(9.0).versusNew)
+        assertNull(summarize(emptyList()).versusNew)
+    }
+
+    @Test
+    fun `a battery that got better than new says so rather than clamping`() {
+        // Ordinary noise on a young pair, and pretending otherwise would be inventing a figure.
+        assertEquals(1.2, cyclesOf(5.0, 6.0).versusNew!!, 0.0001)
     }
 
     @Test

--- a/app/src/test/java/it/eldavo/ylih/tracking/ReceiversTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/tracking/ReceiversTest.kt
@@ -85,6 +85,16 @@ class ReceiversTest {
         shadowOf(Looper.getMainLooper()).idle()
     }
 
+    /** The battery broadcast, whose extra the SDK cannot name — see [BatteryBroadcast]. */
+    private fun broadcastBattery(level: Int, device: BluetoothDevice = headset()) {
+        app.sendBroadcast(
+            Intent(BatteryBroadcast.ACTION_BATTERY_LEVEL_CHANGED)
+                .putExtra(BluetoothDevice.EXTRA_DEVICE, device)
+                .putExtra(BatteryBroadcast.EXTRA_BATTERY_LEVEL, level),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
     /**
      * `goAsync()` borrows the process from Android and hands back a token; returning it in a
      * `finally` is the only reason a receiver that failed is a lost session rather than a
@@ -95,6 +105,10 @@ class ReceiversTest {
     private fun broadcastAndAwaitFinish(action: String, device: BluetoothDevice? = null) {
         val intent = Intent(action)
         device?.let { intent.putExtra(BluetoothDevice.EXTRA_DEVICE, it) }
+        sendOrderedAndAwaitFinish(intent)
+    }
+
+    private fun sendOrderedAndAwaitFinish(intent: Intent) {
         val finished = AtomicBoolean(false)
         app.sendOrderedBroadcast(
             intent,
@@ -306,5 +320,74 @@ class ReceiversTest {
             "a missed disconnect costs one interval, not forever",
             runBlocking { db.sessionDao().getAll().single { it.id == sessionId }.disconnectedAt },
         )
+    }
+
+    private fun batterySamples() = runBlocking { db.batterySampleDao().getAll() }
+
+    /**
+     * The battery broadcast is `@SystemApi` and so is named by its string here as it is in the
+     * app — dispatched through the real manifest filter, because a receiver the merged manifest
+     * does not carry is a feature that works in a test and nowhere else.
+     */
+    @Test
+    fun `battery levels reported during a session become charge-cycle readings`() {
+        listHeadsetAsConnected()
+        broadcast(BluetoothDevice.ACTION_ACL_CONNECTED, headset())
+        settle("the session to open") { sessions().isNotEmpty() }
+
+        broadcastBattery(90)
+        settle("the first reading to land") { batterySamples().isNotEmpty() }
+        broadcastBattery(80)
+        settle("the second reading to land") { batterySamples().size == 2 }
+
+        assertEquals(listOf(90, 80), batterySamples().map { it.level })
+        assertEquals(sessions().single().id, batterySamples().first().sessionId)
+    }
+
+    @Test
+    fun `the level a disconnect announces is not a reading`() {
+        listHeadsetAsConnected()
+        broadcast(BluetoothDevice.ACTION_ACL_CONNECTED, headset())
+        settle("the session to open") { sessions().isNotEmpty() }
+
+        // -1 is BATTERY_LEVEL_UNKNOWN, which the stack broadcasts for every device on every
+        // disconnect; -100 is BATTERY_LEVEL_BLUETOOTH_OFF. Taken at face value the first is a
+        // drop of the whole battery into nothing.
+        broadcastBattery(-1)
+        broadcastBattery(-100)
+        broadcastBattery(70)
+
+        settle("the real reading to land") { batterySamples().isNotEmpty() }
+        assertEquals(listOf(70), batterySamples().map { it.level })
+    }
+
+    @Test
+    fun `a battery broadcast the receiver cannot use is dropped, not crashed`() {
+        // Every one of these returns before goAsync(), so nothing is left pending either way.
+        BtBatteryReceiver().onReceive(app, Intent(Intent.ACTION_POWER_CONNECTED))
+        BtBatteryReceiver().onReceive(app, Intent(BatteryBroadcast.ACTION_BATTERY_LEVEL_CHANGED))
+        // A car stereo reports its battery like anything else on the link, and nobody wears one.
+        BtBatteryReceiver().onReceive(
+            app,
+            Intent(BatteryBroadcast.ACTION_BATTERY_LEVEL_CHANGED)
+                .putExtra(BluetoothDevice.EXTRA_DEVICE, carStereo())
+                .putExtra(BatteryBroadcast.EXTRA_BATTERY_LEVEL, 80),
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(batterySamples().isEmpty())
+    }
+
+    @Test
+    fun `a battery reading the database cannot record costs the reading, not the process`() {
+        db.close()
+
+        sendOrderedAndAwaitFinish(
+            Intent(BatteryBroadcast.ACTION_BATTERY_LEVEL_CHANGED)
+                .putExtra(BluetoothDevice.EXTRA_DEVICE, headset())
+                .putExtra(BatteryBroadcast.EXTRA_BATTERY_LEVEL, 80),
+        )
+
+        assertFailureWasLoggedBy("BtBatteryReceiver")
     }
 }

--- a/app/src/test/java/it/eldavo/ylih/ui/BarChartTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/BarChartTest.kt
@@ -131,6 +131,28 @@ class BarChartTest {
         compose.onNodeWithContentDescription("cycle 1 – cycle 2", substring = true).assertExists()
     }
 
+    /**
+     * A pair worn daily for a decade is some three thousand charge cycles, and three thousand bars
+     * on a phone is a bar narrower than a pixel drawn three thousand times a frame. Averaging runs
+     * of them keeps the only thing the chart is read for — whether the bars are getting shorter.
+     */
+    @Test
+    fun `more cycles than there are bars are averaged into the bars there are`() {
+        assertEquals(listOf(1L, 2L, 3L), bucketedBars(listOf(1L, 2L, 3L), max = 4))
+        assertEquals(listOf(1L, 2L, 3L), bucketedBars(listOf(1L, 2L, 3L), max = 3))
+
+        // Six into four does not divide, so runs of two make three buckets rather than five.
+        assertEquals(listOf(15L, 35L, 55L), bucketedBars(listOf(10L, 20L, 30L, 40L, 50L, 60L), 4))
+
+        // The last run may be short and is still the average of what is in it.
+        assertEquals(listOf(15L, 30L), bucketedBars(listOf(10L, 20L, 30L), max = 2))
+
+        val many = (1..3_000).map { it.toLong() }
+        val bars = bucketedBars(many, max = 40)
+        assertTrue("never more bars than asked for: ${bars.size}", bars.size <= 40)
+        assertTrue("and the shape survives", bars.first() < bars.last())
+    }
+
     @Test
     fun `an empty series draws an empty chart rather than crashing`() {
         show(emptyList())

--- a/app/src/test/java/it/eldavo/ylih/ui/BarChartTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/BarChartTest.kt
@@ -93,6 +93,44 @@ class BarChartTest {
         ).assertExists()
     }
 
+    private fun showCycles(values: List<Long>) {
+        compose.setContent {
+            YlihTheme {
+                CycleBarChart(
+                    values = values,
+                    label = "charge cycles",
+                    firstLabel = "cycle 1",
+                    lastLabel = "cycle ${values.size}",
+                )
+            }
+        }
+        compose.onRoot().captureToImage()
+    }
+
+    /**
+     * The cycle chart draws the same bars against a different axis — an ordinal rather than a date
+     * — because the only thing it is read for is whether the bars get shorter.
+     */
+    @Test
+    fun `the cycle chart is labelled with its span and its best cycle`() {
+        showCycles(listOf(10 * hour, 8 * hour, 6 * hour))
+
+        compose.onNodeWithText("cycle 1", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText("cycle 3", useUnmergedTree = true).assertExists()
+        compose.onNodeWithText(
+            app.getString(R.string.chart_max, formatHours(10 * hour)),
+            useUnmergedTree = true,
+        ).assertExists()
+    }
+
+    @Test
+    fun `the cycle chart tells a screen reader what it is a chart of`() {
+        showCycles(listOf(10 * hour, 6 * hour))
+
+        compose.onNodeWithContentDescription("charge cycles", substring = true).assertExists()
+        compose.onNodeWithContentDescription("cycle 1 – cycle 2", substring = true).assertExists()
+    }
+
     @Test
     fun `an empty series draws an empty chart rather than crashing`() {
         show(emptyList())

--- a/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
@@ -306,6 +306,11 @@ class PairDetailScreenTest {
         compose.onNodeWithContentDescription(
             "${text(R.string.pair_charge_watched)}: ${formatHours(6 * hour)}",
         ).assertExists()
+        // Five hours for the first cycle and one for the second: a fifth of what it managed new.
+        // With two cycles the window is one, so this really is the last against the first.
+        compose.onNodeWithContentDescription(
+            "${text(R.string.pair_vs_new)}: ${formatPercent(0.2)}",
+        ).assertExists()
 
         // One row per completed cycle, and the shape of the two is the whole point of the section:
         // five of the six hours went to the first, one to the second — the same battery buying

--- a/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.test.core.app.ApplicationProvider
 import it.eldavo.ylih.R
 import it.eldavo.ylih.YlihApp
+import it.eldavo.ylih.data.BatterySampleEntity
 import it.eldavo.ylih.data.DeviceEntity
 import it.eldavo.ylih.data.DeviceKind
 import it.eldavo.ylih.data.EndReason
@@ -29,6 +30,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -170,6 +172,93 @@ class PairDetailScreenTest {
     }
 
     private fun pair(pairId: Long) = runBlocking { db.pairDao().byId(pairId) }
+
+    /**
+     * The row naming cycle [number], reporting [ms].
+     *
+     * Matched on its text rather than on its description, which is what tells it apart from the
+     * chart above it: the chart describes its own axis as "cycle 1 – cycle 2 · 5.0h max" — so it
+     * answers to the same names — but its labels are cleared from the semantics tree and it has no
+     * text at all.
+     */
+    private fun assertCycleRow(number: Int, ms: Long) {
+        val name = text(R.string.pair_cycle_number, number)
+        // The rows are listed newest first, so the oldest cycle is the furthest down the list.
+        scrollTo(name)
+        compose.onNode(
+            hasText(name, substring = true).and(hasText(formatHours(ms), substring = true)),
+        ).assertExists()
+    }
+
+    /**
+     * Two full cycles over the three sessions [seedPair] writes: sixty points in the first four
+     * hours, forty in the next one — which completes the first hundred — and a hundred more in the
+     * last hour. Six hours of listening for two cycles, so a charge is worth three.
+     */
+    private fun seedBatteryReadings() = runBlocking {
+        val sessions = db.sessionDao().getAll()
+        fun reading(sessionId: Long, at: Long, level: Int) = runBlocking {
+            db.batterySampleDao().insert(BatterySampleEntity(sessionId = sessionId, at = at, level = level))
+        }
+        reading(sessions[0].id, now - 3 * day, 100)
+        reading(sessions[0].id, now - 3 * day + 4 * hour, 40)
+        reading(sessions[1].id, now - 2 * day, 100)
+        reading(sessions[1].id, now - 2 * day + hour, 60)
+        reading(sessions[2].id, now - hour, 100)
+        reading(sessions[2].id, now, 0)
+    }
+
+    /**
+     * Battery is the one thing here the headphones have to volunteer — it reaches Android over
+     * HFP, Apple's vendor command or BLE's battery service, and plenty of headsets speak none of
+     * them. A pair that has never reported one gets no section rather than an empty one.
+     *
+     * Asserted by scrolling rather than by counting nodes: the list composes what is on screen, so
+     * "no node with this text" is true of every section below the fold and would pass whatever the
+     * screen did.
+     */
+    @Test
+    fun `a pair whose headphones never report their battery has no charge section`() {
+        val pairId = seedPair()
+
+        show(pairId)
+
+        assertTrue(
+            "the whole list was searched and there is no charge section in it",
+            runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isFailure,
+        )
+    }
+
+    @Test
+    fun `charge cycles report what a charge is worth and what each one bought`() {
+        val pairId = seedPair()
+        seedBatteryReadings()
+
+        show(pairId)
+        // The readings arrive from Room a frame or more after the summary does, so the section
+        // may not be in the list yet on the first attempt.
+        compose.waitUntil(timeoutMillis = 10_000) {
+            runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isSuccess
+        }
+
+        // Two hundred points over six hours, so a hundred of them is three. The three tiles are in
+        // the same list item as the heading just scrolled to.
+        compose.onNodeWithContentDescription(
+            "${text(R.string.pair_per_charge)}: ${formatHours(3 * hour)}",
+        ).assertExists()
+        compose.onNodeWithContentDescription(
+            "${text(R.string.pair_cycles)}: ${formatCycles(2.0)}",
+        ).assertExists()
+        compose.onNodeWithContentDescription(
+            "${text(R.string.pair_charge_watched)}: ${formatHours(6 * hour)}",
+        ).assertExists()
+
+        // One row per completed cycle, and the shape of the two is the whole point of the section:
+        // five of the six hours went to the first, one to the second — the same battery buying
+        // less than it used to.
+        assertCycleRow(number = 1, ms = 5 * hour)
+        assertCycleRow(number = 2, ms = hour)
+    }
 
     @Test
     fun `the page reports lifetime, playback, cost and every session`() {

--- a/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
@@ -171,6 +171,11 @@ class PairDetailScreenTest {
             .performScrollToNode(hasText(value, substring = true))
     }
 
+    /** [scrollTo] where a substring would be ambiguous — "cycle 1" against "cycle 19". */
+    private fun scrollToExact(value: String) {
+        compose.onNode(hasScrollToNodeAction()).performScrollToNode(hasText(value))
+    }
+
     private fun pair(pairId: Long) = runBlocking { db.pairDao().byId(pairId) }
 
     /**
@@ -197,8 +202,11 @@ class PairDetailScreenTest {
      */
     private fun seedBatteryReadings() = runBlocking {
         val sessions = db.sessionDao().getAll()
+        val pairId = db.pairDao().getAll().single().id
         fun reading(sessionId: Long, at: Long, level: Int) = runBlocking {
-            db.batterySampleDao().insert(BatterySampleEntity(sessionId = sessionId, at = at, level = level))
+            db.batterySampleDao().insert(
+                BatterySampleEntity(sessionId = sessionId, pairId = pairId, at = at, level = level),
+            )
         }
         reading(sessions[0].id, now - 3 * day, 100)
         reading(sessions[0].id, now - 3 * day + 4 * hour, 40)
@@ -227,6 +235,52 @@ class PairDetailScreenTest {
             "the whole list was searched and there is no charge section in it",
             runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isFailure,
         )
+    }
+
+    /** One session per cycle, a hundred points each, so [count] cycles complete. */
+    private fun seedManyCycles(pairId: Long, count: Int) = runBlocking {
+        repeat(count) { i ->
+            val at = now - (count - i) * day
+            val sessionId = db.sessionDao().insert(
+                SessionEntity(
+                    pairId = pairId,
+                    connectedAt = at,
+                    disconnectedAt = at + 5 * hour,
+                    heartbeatAt = at + 5 * hour,
+                    endReason = EndReason.DISCONNECTED,
+                ),
+            )
+            db.batterySampleDao()
+                .insert(BatterySampleEntity(sessionId = sessionId, pairId = pairId, at = at, level = 100))
+            db.batterySampleDao().insert(
+                BatterySampleEntity(sessionId = sessionId, pairId = pairId, at = at + 5 * hour, level = 0),
+            )
+        }
+    }
+
+    /**
+     * Cycles accumulate for the life of the pair — daily use for a decade is some three thousand —
+     * and the day list above them is bounded by its window while these are not. Listing every one
+     * would put an unbounded scroll between the chart and the sessions underneath it.
+     */
+    @Test
+    fun `only the most recent charge cycles are listed, however many there are`() {
+        val pairId = seedPair()
+        seedManyCycles(pairId, count = 30)
+
+        show(pairId)
+        compose.waitUntil(timeoutMillis = 10_000) {
+            runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isSuccess
+        }
+
+        // The newest is listed and the oldest is not, and the sessions below stay reachable.
+        // Exactly, not by substring: "cycle 1" is a substring of "cycle 19", which *is* listed.
+        scrollToExact(text(R.string.pair_cycle_number, 30))
+        assertTrue(
+            "the whole list was searched and cycle 1 is not in it",
+            runCatching { scrollToExact(text(R.string.pair_cycle_number, 1)) }.isFailure,
+        )
+        scrollTo(text(R.string.session_ongoing))
     }
 
     @Test


### PR DESCRIPTION
Closes #30.

The pair page grows a **charge cycles** section: *per charge* (hours of listening one full cycle buys), *vs when new* (a percentage), *cycles*, *watched*, a bar per completed cycle oldest-first, and a row per cycle with its dates. A battery that is wearing out reads as a staircase going down — which is the question the issue asked.

A cycle is **100 percentage points used**, however many part-charges that took. The section is absent until the headphones have actually reported their battery; plenty never do, and an empty section explaining that would be a permanent apology on every pair that has one.

## Getting the battery at all

Android has no public API for it. The stack broadcasts one, and three things — each checked against AOSP and then on a phone — make depending on the hidden name safe rather than hopeful:

- `RemoteDevices.sendBatteryLevelChangedBroadcast` sends it with **`BLUETOOTH_CONNECT`** as the receiver permission, not `BLUETOOTH_PRIVILEGED`. This app already holds it.
- It carries `FLAG_RECEIVER_INCLUDE_BACKGROUND` — the flag `BroadcastSkipPolicy.disallowBackgroundStart` reads — so a manifest receiver runs with nothing of ours resident.
- It is a `<protected-broadcast>`, so no other app can forge a battery level into the database.

## Only drain we watched is counted

A drop counts only between two readings **inside one session**, so `battery_samples` is keyed on `sessionId` — the rule is a property of the schema instead of something to remember. Counting across a gap would break the figure twice: there is no listening to attach to it, and a headset charged partway through the gap reports a level that makes the drain look smaller than it was, with nothing to say so.

`stats/Charge.kt` is the whole calculation, pure and Room-free like `Stats.kt`. It apportions playback across a segment with the same even spread `Stats.dailyMs` uses across midnight, and drops a session that never measured playback from *both* sides of the ratio, as `Stats.counted` does.

## ⚠️ A live bug in the shipped app, found on a phone

**Both Bluetooth receivers had to be `exported="true"`.** The Bluetooth stack is a separate app (uid 1002), and an implicit broadcast from another app no longer resolves a non-exported component of ours: AMS drops it in `SaferIntentUtils.filterNonExportedComponents`, *before* the `BroadcastRecord` exists, so it does not even appear as a skipped receiver in `dumpsys activity broadcasts`. Measured on a Mi 10T running Android 16, `BtConnectionReceiver` saw nothing across five Bluetooth off/on cycles while another app's *exported* receiver logged every one; flipping the attribute alone made both fire on the next cycle. That receiver is the whole of Bluetooth-only tracking. Exporting costs nothing, because these are protected broadcasts only the system may send.

**Reviewer's call:** that fix is a pre-existing bug riding along with a feature, and is easy to split out if you would rather land it separately — it is one attribute plus its comment.

## The first reading of a session arrives before the session does

ACL_CONNECTED at 08:20:52.721, the battery broadcast at 08:20:53.131, and `BtConnectionReceiver`'s own row at 08:20:53.199 — 68 ms too late, and the reading was dropped. The two receivers race by construction, since the connect one reads the tracking mode before it writes. `recordBatteryLevel` now reports whether it found an open session, and the reading is retried once. Not a rarity to tidy up later: many headsets report their battery only at connect, so without the retry those pairs record nothing at all.

## Scale

Charge cycles are the one figure with no window, so a decade of them is the case to design for. Each of these was measured:

- **The read must not name `sessions`.** A Room flow observes every table its query mentions, and the heartbeat writes to `sessions` once a minute — so the joined read of 400,000 readings took 3.5 s and re-ran *every minute* while the pair page was open. `battery_samples` carries a redundant `pairId`, making it a covering scan of `(pairId, at)`: 1.5 s, no join, no sort, and only when a reading lands.
- **The summary is off the main thread.** `Charge.summarize` is 173 ms over a million readings; it lives in `YlihViewModel.chargeSummary` on `Dispatchers.Default`, with sessions reduced to spans *before* `distinctUntilChanged` so a heartbeat recomputes nothing.
- **The list and chart are bounded.** Rows stop at 12 with absolute numbering; the chart averages runs into at most 40 bars. The tiles stay exact, being counted rather than drawn.

## Verification

Unit tests on all four legs (`classic`/`play` × `debug`/`releaseTest`); lint, both R8 keep-checks and both coverage gates pass (classic 95.9 / 98.9 / 76.0, play 96.1 / 99.1 / 76.2 against floors of 95 / 98 / 70). New tests: `ChargeTest` (22 cases), the retry and reading contract in `SessionRepositoryTest`, receiver dispatch through the real manifest filter in `ReceiversTest`, a v3→v4 migration case, a backup round-trip, the bar bucketing, and the pair-page section including the row cap.

On the phone, end to end, twice: the headset reported **50** in the morning and **40** that evening, both landing as rows against the right session. That also settles granularity — battery arrives as `AT+BIEV=2,<0-100>`, a real percentage; the five-step `+CIND` ladder is reached only from the HFP **client** role, which no pair of headphones takes.

## Notes

- Room goes to **v4** with `MIGRATION_3_4`; the SQL is byte-identical to what KSP generates, and `4.json` is committed.
- Backups carry readings behind a default rather than a format bump, as `settings` did.
- One scoped `lint.xml` entry: `UnsafeImplicitIntentLaunch` for `ReceiversTest.kt` only, with the reason in the file.
- Six new strings across all **220** locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFGb7nKgNU4sAzEkXwe4YZ