### PR TITLE
restore exported=false on the bluetooth connection receiver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,15 +206,22 @@ last, and how has that changed" — the battery-degradation curve issue #30 aske
 
 Three things here are load-bearing and none of them is obvious.
 
-**Both Bluetooth receivers must be `exported="true"`, and this was found on a phone.** The Bluetooth
-stack is a separate app (uid 1002), and an implicit broadcast from another app no longer resolves a
-non-exported component of ours — AMS drops it in `SaferIntentUtils.filterNonExportedComponents`,
-*before* the `BroadcastRecord` exists, so it does not even show as a skipped receiver in `dumpsys
-activity broadcasts`. Measured on a Mi 10T running Android 16: with `exported="false"`,
-`BtConnectionReceiver` saw nothing across five Bluetooth off/on cycles while another app's exported
-receiver logged every one; flipping the attribute alone made both receivers fire on the next cycle.
-That attribute is the whole of Bluetooth-only tracking, so it was a live bug in the shipped app and
-not only a charge-cycles concern. Exporting costs nothing because these are protected broadcasts.
+**`BtConnectionReceiver` is `exported="false"`, and a claim that it had to be `"true"` was checked
+on a phone and found wrong.** #31 measured a Mi 10T on Android 16 and concluded a non-exported
+manifest receiver no longer resolves an implicit broadcast from another app — the Bluetooth stack
+is a separate app (uid 1002) — and shipped both Bluetooth receivers exported. #33 went back to the
+same phone with the *released* build, still `exported="false"`, and found it working: an open
+session, a scheduled `HeartbeatWorker`, and no path to either except `BtConnectionReceiver` having
+received `ACL_CONNECTED` sixteen hours after the last time `MainActivity` ran and with no reboot in
+between. The original A/B was run against a `.debug` install that had been installed, launched,
+force-stopped and `pm clear`ed repeatedly that evening, and every flip of the attribute came with a
+reinstall; a package in the *stopped* state receives no broadcasts until something launches it, so
+"the attribute" and "the reinstall that lifted the stopped state" were never actually separated.
+`BtBatteryReceiver` is left `exported="true"` regardless — `BATTERY_LEVEL_CHANGED` shares the same
+permission and delivery flags as the ACL broadcasts, so it very probably works non-exported too,
+but that has not been observed on a device the way the ACL case now has, and exporting a receiver
+whose only filter is a protected broadcast costs nothing. Don't re-derive the old conclusion from
+the same `dumpsys` output: check whether the app under test was ever in the stopped state first.
 
 **The broadcast is `@SystemApi` and that is fine — for reasons, not by luck.** Android has no public
 API for a headset's battery. `tracking/BatteryBroadcast.kt` writes out

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,27 +61,13 @@
             android:foregroundServiceType="connectedDevice" />
 
         <!--
-          ACL_CONNECTED/ACL_DISCONNECTED carry FLAG_RECEIVER_INCLUDE_BACKGROUND, so this manifest
-          receiver still runs on Android 8+ with nothing of ours resident.
-
-          exported="true", and it has to be. This used to read "false" with a comment saying the
-          system delivers protected broadcasts to non-exported receivers — which was true when it
-          was written and is not any more. The Bluetooth stack is a separate app (uid 1002), and an
-          implicit broadcast from another app no longer resolves a non-exported component of ours:
-          AMS drops it in SaferIntentUtils.filterNonExportedComponents, before the BroadcastRecord
-          exists, so it does not even appear as a skipped receiver in `dumpsys activity broadcasts`.
-
-          Measured on a Mi 10T running Android 16: with exported="false" this receiver saw nothing
-          across five Bluetooth off/on cycles while another app's *exported* receiver logged every
-          one of them; flipping this attribute alone made it fire on the next cycle. That is the
-          whole of Bluetooth-only tracking, so with it false the default mode records nothing.
-
-          Exporting costs nothing here: both actions are <protected-broadcast>, so only the system
-          may send them and no other app can forge a connection.
+          ACL_CONNECTED/ACL_DISCONNECTED are protected broadcasts carrying
+          FLAG_RECEIVER_INCLUDE_BACKGROUND, so this manifest receiver still runs on Android 8+ with
+          nothing of ours resident, non-exported.
         -->
         <receiver
             android:name=".tracking.BtConnectionReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
                 <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
@@ -92,9 +78,11 @@
           The headset's own battery level, for charge cycles. The action is @SystemApi and so cannot
           be named from the SDK, but it is a protected broadcast sent with BLUETOOTH_CONNECT as its
           receiver permission and the same FLAG_RECEIVER_INCLUDE_BACKGROUND the ACL broadcasts
-          carry — so it reaches a manifest receiver with nothing of ours resident, exactly as they
-          do, and exported for exactly the same reason theirs is. tracking/BatteryBroadcast.kt has
-          the whole reasoning.
+          carry — so it very probably reaches a non-exported receiver with nothing of ours resident,
+          exactly as they do. That has not been checked on a device the way BtConnectionReceiver's
+          delivery has (see CLAUDE.md), so this stays exported="true" for now rather than assume it:
+          a receiver whose only filter is a protected broadcast loses nothing by being exported.
+          tracking/BatteryBroadcast.kt has the whole reasoning.
         -->
         <receiver
             android:name=".tracking.BtBatteryReceiver"

--- a/app/src/main/java/it/eldavo/ylih/tracking/BatteryBroadcast.kt
+++ b/app/src/main/java/it/eldavo/ylih/tracking/BatteryBroadcast.kt
@@ -12,13 +12,13 @@ package it.eldavo.ylih.tracking
  *   `sendBroadcast(intent, BLUETOOTH_CONNECT, …)`. The receiver permission is one this app already
  *   holds for the ACL broadcasts; it is not `BLUETOOTH_PRIVILEGED`, which is what would put it out
  *   of reach.
- * - **A manifest receiver is enough, provided it is exported.** It carries
- *   `FLAG_RECEIVER_INCLUDE_BACKGROUND`, the flag `BroadcastSkipPolicy.disallowBackgroundStart`
- *   reads — the same mechanism that lets [BtConnectionReceiver] run with nothing of this app
- *   resident. The stack sets identical delivery flags on the ACL broadcast and on this one, so the
- *   two arrive on the same terms, `android:exported` included: the sender is another app, and a
- *   non-exported component of ours is dropped from an implicit broadcast before the
- *   `BroadcastRecord` is even built. The manifest carries the measurement.
+ * - **A manifest receiver is enough.** It carries `FLAG_RECEIVER_INCLUDE_BACKGROUND`, the flag
+ *   `BroadcastSkipPolicy.disallowBackgroundStart` reads — the same mechanism that lets
+ *   [BtConnectionReceiver] run with nothing of this app resident. The stack sets identical
+ *   delivery flags and the same receiver permission on the ACL broadcast and on this one, so it
+ *   very probably reaches a non-exported receiver too; that has not been checked on a device the
+ *   way the ACL case has, which is why the manifest still declares this one `exported="true"`
+ *   rather than assume it.
  * - **Nobody can forge it.** It is declared `<protected-broadcast>` in the framework's own manifest,
  *   so only the system may send it and no other app can write a battery level into our database —
  *   which is also what makes exporting the receiver free of consequence.


### PR DESCRIPTION
#31 changed both Bluetooth receivers to exported="true" and recorded, in four places, a
measurement said to justify it: that AMS drops an implicit broadcast aimed at a non-exported
component before the BroadcastRecord exists, so BtConnectionReceiver was receiving nothing and
Bluetooth-only tracking was silently dead. The conclusion was wrong, and the released build is
the proof — it carries exported="false" and works on the same phone the measurement was taken on.

Read off that phone with the released build installed: dumpsys jobscheduler showed a
#HeartbeatWorker# job scheduled, and updateHeartbeatWork() enqueues that only when
hasOpenSessions() is true and cancels it otherwise, so the app believed a session was open.
MainActivity had last resumed sixteen hours earlier, ruling out syncWithSystem() from onStart;
the phone had not rebooted, ruling out BootReceiver; and HeartbeatWorker only exists once a
session is already open. Nothing is left but BtConnectionReceiver having received ACL_CONNECTED
while non-exported.

What misled the original A/B is worth writing down, because the same dumpsys output will be read
again. It was run against the .debug install, which had been installed, launched, force-stopped
and pm cleared repeatedly that evening, and every flip of the attribute came with a reinstall. A
package in the stopped state receives no broadcasts until something launches it, so "the
attribute" and "the reinstall that lifted the stopped state" were never separated. The reading
where our receiver was absent from the ACL record is real, and has the same confound.

BtBatteryReceiver stays exported="true", and its comment now says this is unproven rather than
justified. BATTERY_LEVEL_CHANGED is sent by the same code path with the same delivery flags and
the same BLUETOOTH_CONNECT receiver permission as the ACL broadcasts, so it very probably works
non-exported too — but that has not been observed on a device the way the ACL case now has, and a
receiver whose only filter is a protected broadcast loses nothing by being exported. Reverting it
blind would break charge cycles invisibly, which is the one failure mode worth avoiding here. The
three AOSP facts in BatteryBroadcast.kt's KDoc are all still true and still checked, and stay; only
the claim about non-exported components is removed.

Nothing in CI can test the behavioural half of this, which is why the safe half is reverted and
the unproven half left alone. What CI does cover is unchanged and already green in this shape:
exported="false" is what shipped from the initial commit until #31, and ReceiversTest has
dispatched ACL_CONNECTED through the real manifest filter against a non-exported receiver since
before that commit. It also passed lint that way with no suppression, which is the evidence that
lint exempts the ACL actions as protected broadcasts — so the scoped UnsafeImplicitIntentLaunch
ignore for ReceiversTest.kt is unaffected and stays as it is.

Closes #33.
