### PR TITLE
give navigation one motion: the pair page fades as it scales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,8 +401,9 @@ with the figure the bar can only be a proportion of. Three things about it:
 single `tabs` route, so they can be swiped between: pages are laid out side by side and the screen
 follows the finger, which is a thing a NavHost swapping its content on a click cannot do at all —
 the most it could offer was a slide animation. What is left in the back stack is the pair page,
-which is a genuine push over whichever tab was showing and still crossfades, in step with the app
-bar `AnimatedVisibility` that reads the same `NAV_FADE`. Three consequences worth knowing:
+which is a genuine push over whichever tab was showing and runs `ui/NavMotion.kt`'s spec, in step
+with the app bar `AnimatedVisibility` that reads the fade half of it. Three consequences worth
+knowing:
 
 - The pager state is hoisted above the `NavHost`, because the tabs leave the composition while
   the pair page is open and a state remembered down there would hand back the first tab on the
@@ -412,6 +413,15 @@ bar `AnimatedVisibility` that reads the same `NAV_FADE`. Three consequences wort
   tab. It is disabled on the pair page: the `NavHost` registers its handler after this one and so
   wins, but only while it has something to pop.
 - Nothing needs doing for RTL — a horizontal pager reverses itself, as the nav bar does.
+
+That spec is one file rather than four lambdas' worth of constants because the bar is not a
+destination and is faded by hand, so the two only stay in step if they read the same thing. Each
+transition is a fade *and* a scale on one 700 ms tween, and the pop is the mirror of the push — the
+page compresses back the way it grew. The fade on the pop is the load-bearing half: predictive back
+seeks our own `popExitTransition` rather than supplying one, so a scale without it is a page still
+fully drawn at the end of the animation and then simply gone, which is what #38 reported. The bar
+stays fade-only: it has to hold its height for the whole exit, which is what stops the list under it
+jerking, and a scale would give that back.
 
 `YlihNavHostTest` drives the swipe by finding the one node on screen with a horizontal scroll
 range, the tabs' own lists all being vertical.

--- a/app/src/main/java/it/eldavo/ylih/ui/NavMotion.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/NavMotion.kt
@@ -1,0 +1,51 @@
+package it.eldavo.ylih.ui
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+
+/**
+ * The one motion every in-app navigation runs on.
+ *
+ * It is a file rather than a handful of constants beside their callers because the app bar is not a
+ * destination — it sits in the Scaffold, outside the NavHost — and has to be faded by hand to stay
+ * in step with the screens behind it. Two specs written twice stay in step only as long as whoever
+ * edits one remembers the other; one spec read from both places makes it literal.
+ */
+
+// The duration is shared by the alpha and the scale of every transition below, and that sharing is
+// the point: a scale that outlives its fade ends by snapping out of existence, which is what the
+// pop used to do. 700ms is the number these transitions have always run at; only the shape changed.
+internal const val NAV_MOTION_MS = 700
+
+// A screen that is further away, and a screen that is closer than the one in front of the user.
+// Forward navigation grows the arriving page from AWAY while the leaving one swells past TOWARD;
+// the pop is the mirror, so going back compresses exactly where going in expanded. Predictive back
+// seeks our own popExit rather than adding one of its own, so the gesture is this same animation.
+internal const val NAV_SCALE_AWAY = 0.92f
+internal const val NAV_SCALE_TOWARD = 1.05f
+
+private val navSpec = tween<Float>(durationMillis = NAV_MOTION_MS)
+
+internal fun navEnter(): EnterTransition =
+    fadeIn(navSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_AWAY)
+
+internal fun navExit(): ExitTransition =
+    fadeOut(navSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_TOWARD)
+
+internal fun navPopEnter(): EnterTransition =
+    fadeIn(navSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_TOWARD)
+
+internal fun navPopExit(): ExitTransition =
+    fadeOut(navSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_AWAY)
+
+// The bar fades and does not scale. It trades places with the pair page's own bar and has to hold
+// its height for the whole exit — see the comment at its AnimatedVisibility — so scaling it would
+// bring back the jerk in the content underneath that holding the height exists to prevent.
+internal fun barEnter(): EnterTransition = fadeIn(navSpec)
+
+internal fun barExit(): ExitTransition = fadeOut(navSpec)

--- a/app/src/main/java/it/eldavo/ylih/ui/YlihNavHost.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/YlihNavHost.kt
@@ -3,9 +3,6 @@ package it.eldavo.ylih.ui
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -95,13 +92,11 @@ private const val TAB_STATS = 1
 private const val TABS_ROUTE = "tabs"
 private const val PAIR_ROUTE = "pair/{pairId}"
 
-// What is left in the back stack is the pair page, and it crossfades. The app bar is not a
-// destination — it sits in the Scaffold, outside the NavHost — so it has to be faded by hand to
-// stay in step, and the two only stay in step if they read the same spec. Hence the NavHost gets
-// its transitions passed explicitly below rather than inheriting navigation-compose's default
-// (identical today: fadeIn/fadeOut of tween(700)); an inherited default is a number that can
-// change under us in a dependency bump.
-private val NAV_FADE = tween<Float>(durationMillis = 700)
+// What is left in the back stack is the pair page, and it both scales and fades: the spec lives in
+// NavMotion.kt, which says why it is one spec and why the bar reads the fade half of it alone. The
+// NavHost gets its four transitions passed explicitly rather than inheriting navigation-compose's
+// defaults — an inherited default is a shape and a number that can change under us in a dependency
+// bump, and the bar has no way to follow it.
 
 /**
  * How wide a screen's content is ever allowed to get.
@@ -290,8 +285,8 @@ fun YlihNavHost(
                 // bar untouched, which is the point of hoisting it here.
                 AnimatedVisibility(
                     visible = currentRoute != PAIR_ROUTE,
-                    enter = fadeIn(NAV_FADE),
-                    exit = fadeOut(NAV_FADE),
+                    enter = barEnter(),
+                    exit = barExit(),
                 ) {
                     MediumFlexibleTopAppBar(
                         title = {
@@ -343,10 +338,10 @@ fun YlihNavHost(
             NavHost(
                 navController = navController,
                 startDestination = TABS_ROUTE,
-                enterTransition = { fadeIn(NAV_FADE) },
-                exitTransition = { fadeOut(NAV_FADE) },
-                popEnterTransition = { fadeIn(NAV_FADE) },
-                popExitTransition = { fadeOut(NAV_FADE) },
+                enterTransition = { navEnter() },
+                exitTransition = { navExit() },
+                popEnterTransition = { navPopEnter() },
+                popExitTransition = { navPopExit() },
             ) {
                 composable(TABS_ROUTE) {
                     HorizontalPager(

--- a/app/src/test/java/it/eldavo/ylih/ui/NavMotionTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/NavMotionTest.kt
@@ -1,0 +1,91 @@
+package it.eldavo.ylih.ui
+
+import android.os.Build
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The spec every in-app navigation runs on. What is worth pinning is not the numbers themselves —
+ * they are a judgement — but the two relations that stop the motion looking broken: that the scale
+ * of a transition never outlives its fade, and that going back is the mirror of going in.
+ *
+ * A transition's own fields are internal to the animation library, so the shape is read back the
+ * only way a caller can: by rebuilding the transition from a scale recovered out of its `toString`
+ * and asserting it is equal to the real one. Equality covers everything the rebuild does *not*
+ * mention as well — a slide or a size change would make these fail.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+class NavMotionTest {
+
+    private val spec = tween<Float>(durationMillis = NAV_MOTION_MS)
+
+    /** The scale factor a transition animates through, as it describes itself. */
+    private fun scaleOf(transition: Any): Float {
+        val description = transition.toString()
+        val match = SCALE.find(description)
+        assertTrue("no scale in $description", match != null)
+        return checkNotNull(match).groupValues[1].toFloat()
+    }
+
+    @Test
+    fun `every navigation transition fades and scales on one spec`() {
+        // The failure this rules out is the one that was reported: a scale on a longer spec than
+        // the alpha, or with no alpha at all, ends with the screen still fully drawn and then gone.
+        assertEquals(
+            "forward enter",
+            fadeIn(spec) + scaleIn(spec, initialScale = scaleOf(navEnter())),
+            navEnter(),
+        )
+        assertEquals(
+            "forward exit",
+            fadeOut(spec) + scaleOut(spec, targetScale = scaleOf(navExit())),
+            navExit(),
+        )
+        assertEquals(
+            "pop enter",
+            fadeIn(spec) + scaleIn(spec, initialScale = scaleOf(navPopEnter())),
+            navPopEnter(),
+        )
+        assertEquals(
+            "pop exit",
+            fadeOut(spec) + scaleOut(spec, targetScale = scaleOf(navPopExit())),
+            navPopExit(),
+        )
+    }
+
+    @Test
+    fun `going back is the mirror of going in`() {
+        // Whatever the numbers are, the pair page has to leave the way it arrived and the tabs have
+        // to come back the way they left; otherwise a push and its pop are two different animations
+        // and a predictive-back gesture, which seeks the pop, shows neither of them properly.
+        assertEquals("the arriving page compresses back the way it grew",
+            scaleOf(navEnter()), scaleOf(navPopExit()), 0f)
+        assertEquals("and the page underneath returns from where it went",
+            scaleOf(navExit()), scaleOf(navPopEnter()), 0f)
+
+        assertTrue("one direction is further away", scaleOf(navEnter()) < 1f)
+        assertTrue("the other is closer", scaleOf(navExit()) > 1f)
+    }
+
+    @Test
+    fun `the app bar fades on the same duration and does not scale`() {
+        // It is outside the NavHost and faded by hand, so this is the only thing keeping it in step
+        // with the destinations. It stays scale-free on purpose — it has to hold its height.
+        assertEquals(fadeIn(spec), barEnter())
+        assertEquals(fadeOut(spec), barExit())
+    }
+
+    private companion object {
+        val SCALE = Regex("""Scale\(scale=(-?[0-9.]+)""")
+    }
+}

--- a/app/src/test/java/it/eldavo/ylih/ui/YlihNavHostTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/YlihNavHostTest.kt
@@ -211,6 +211,40 @@ class YlihNavHostTest {
     }
 
     @Test
+    fun `the pair page shrinks on its way out rather than only fading`() {
+        // The reported failure was the pop being a scale with no fade, which ends with the page
+        // still fully drawn and then simply gone. Asserted by geometry rather than by the spec, the
+        // way the rail and the bar are told apart: the spec is a constant, this is the animation
+        // actually running on the page.
+        val label = "ACCENTUM Plus"
+        seedPair(label)
+        show()
+
+        compose.waitUntil(timeoutMillis = 10_000) { nodeCount(label) > 0 }
+        compose.onNodeWithText(label).performClick()
+        compose.waitUntil(timeoutMillis = 10_000) { route() == PAIR_ROUTE }
+        compose.waitForIdle()
+
+        // boundsInRoot rather than the unclipped Dp bounds: those are the node's own layout size,
+        // which a graphics layer does not touch. These go through localToRoot, so the scale the
+        // transition is running is in them.
+        val backArrow = { compose.onNodeWithContentDescription(text(R.string.pair_back)) }
+        val atRest = backArrow().fetchSemanticsNode().boundsInRoot
+
+        // Hand-driven from here: a pop watched at its own pace is only ever seen finished.
+        compose.mainClock.autoAdvance = false
+        backArrow().performClick()
+        compose.mainClock.advanceTimeBy(NAV_MOTION_MS / 2L)
+
+        val midPop = backArrow().fetchSemanticsNode().boundsInRoot
+        assertTrue(
+            "the pair page is still on screen halfway through its exit, and smaller: " +
+                "$midPop against $atRest at rest",
+            midPop.width < atRest.width && midPop.height < atRest.height,
+        )
+    }
+
+    @Test
     fun `a tab tapped from the pair page comes back to the tabs and shows that one`() {
         // The nav bar is drawn on the pair page too, where a tab means both things at once: leave
         // the page, and land on that tab rather than on whichever one it was opened from.


### PR DESCRIPTION
Moving to a pair and back was a 700 ms crossfade and nothing else, so the only scale in the app was
the one navigation-compose layers on during a predictive-back gesture. That gesture seeks whatever
transitions the NavHost was given, and ours carried alpha only — so the page compressed at full
opacity and then stopped existing when the pop committed, which is the animation #38 reports as
expanding and compressing with no fade.

The four transitions and the app bar's own fade now come from one file, `ui/NavMotion.kt`, and each
carries a scale and a fade on the same tween. Forward, the arriving page grows from 0.92 while the
one it covers swells past 1.0 and fades; the pop is the mirror, so back compresses where forward
expanded and the fade finishes with the scale rather than after it. It is a file rather than four
lambdas' worth of constants for the reason `NAV_FADE` already had a comment: the bar is not a
destination, it sits in the Scaffold and is faded by hand, and the two only stay in step if they
read the same spec.

The bar keeps fade only. It has to hold its height for the whole exit — the comment above its
`AnimatedVisibility` records the list underneath jerking upward the last time that height moved
mid-animation — so a scale there would hand that back. The duration stays the 700 ms that was
already there: the shape was the complaint, and moving both at once would leave no way to say which
one mattered.

Two tests, and they cover different halves. `NavMotionTest` pins the spec by rebuilding each
transition and comparing it whole, which catches a missing fade, a scale on a longer spec than its
alpha, or a slide arriving later; it also pins that push and pop are mirrors and that the bar shares
the destinations' duration. `YlihNavHostTest` pins the animation actually running rather than a
constant: with the clock paused halfway through the pop, the pair page is still on screen and its
`boundsInRoot` — which go through `localToRoot` and so carry the graphics layer's scale — are
narrower than at rest. That is the same geometry-over-presence approach the wide/rail test takes,
for the same reason.

No strings, no dependencies, no schema, and nothing outside the app's own navigation — the
launcher's window transitions are the platform's and are untouched.

Closes #38.

Closes #38.
