### PR TITLE
fade the pair page early so a held back gesture fades too

### DIFF
--- a/app/src/main/java/it/eldavo/ylih/ui/NavMotion.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/NavMotion.kt
@@ -17,10 +17,16 @@ import androidx.compose.animation.scaleOut
  * edits one remembers the other; one spec read from both places makes it literal.
  */
 
-// The duration is shared by the alpha and the scale of every transition below, and that sharing is
-// the point: a scale that outlives its fade ends by snapping out of existence, which is what the
-// pop used to do. 700ms is the number these transitions have always run at; only the shape changed.
+// 700ms is the number these transitions have always run at, and it is the scale that spends all of
+// it. The alpha does not: a predictive-back gesture *seeks* the pop by finger progress rather than
+// playing it, so a fade spread evenly over the whole timeline is still most of the way opaque where
+// a real drag ends, and the release has almost nothing left of the duration to dispose of it in —
+// the page simply disappeared, which is #40. Front-loading the alpha means the page is already
+// transparent at the point the gesture hands over, whatever the commit then chooses to do with the
+// remainder. The scale keeps the full duration and the pop stays the exact mirror of the push.
 internal const val NAV_MOTION_MS = 700
+internal const val NAV_FADE_MS = 400
+internal const val NAV_FADE_DELAY_MS = NAV_MOTION_MS - NAV_FADE_MS
 
 // A screen that is further away, and a screen that is closer than the one in front of the user.
 // Forward navigation grows the arriving page from AWAY while the leaving one swells past TOWARD;
@@ -31,21 +37,29 @@ internal const val NAV_SCALE_TOWARD = 1.05f
 
 private val navSpec = tween<Float>(durationMillis = NAV_MOTION_MS)
 
+// The leaving page fades first and the arriving one last, so the two are never both half-drawn over
+// each other, and neither outlives the scale it rides on: the delay plus the fade is the duration.
+private val fadeOutSpec = tween<Float>(durationMillis = NAV_FADE_MS)
+private val fadeInSpec = tween<Float>(durationMillis = NAV_FADE_MS, delayMillis = NAV_FADE_DELAY_MS)
+
 internal fun navEnter(): EnterTransition =
-    fadeIn(navSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_AWAY)
+    fadeIn(fadeInSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_AWAY)
 
 internal fun navExit(): ExitTransition =
-    fadeOut(navSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_TOWARD)
+    fadeOut(fadeOutSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_TOWARD)
 
 internal fun navPopEnter(): EnterTransition =
-    fadeIn(navSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_TOWARD)
+    fadeIn(fadeInSpec) + scaleIn(navSpec, initialScale = NAV_SCALE_TOWARD)
 
 internal fun navPopExit(): ExitTransition =
-    fadeOut(navSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_AWAY)
+    fadeOut(fadeOutSpec) + scaleOut(navSpec, targetScale = NAV_SCALE_AWAY)
 
 // The bar fades and does not scale. It trades places with the pair page's own bar and has to hold
-// its height for the whole exit — see the comment at its AnimatedVisibility — so scaling it would
-// bring back the jerk in the content underneath that holding the height exists to prevent.
-internal fun barEnter(): EnterTransition = fadeIn(navSpec)
+// its height for as long as the screen behind it is still drawn — see the comment at its
+// AnimatedVisibility — so scaling it would bring back the jerk in the content underneath that
+// holding the height exists to prevent. It reads the same two fade specs as the destinations, which
+// is the whole reason this file exists: AnimatedVisibility gives the height back when its own exit
+// ends, and on the shortened alpha that is the instant the content underneath reaches zero anyway.
+internal fun barEnter(): EnterTransition = fadeIn(fadeInSpec)
 
-internal fun barExit(): ExitTransition = fadeOut(navSpec)
+internal fun barExit(): ExitTransition = fadeOut(fadeOutSpec)

--- a/app/src/main/java/it/eldavo/ylih/ui/YlihNavHost.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/YlihNavHost.kt
@@ -96,7 +96,9 @@ private const val PAIR_ROUTE = "pair/{pairId}"
 // NavMotion.kt, which says why it is one spec and why the bar reads the fade half of it alone. The
 // NavHost gets its four transitions passed explicitly rather than inheriting navigation-compose's
 // defaults — an inherited default is a shape and a number that can change under us in a dependency
-// bump, and the bar has no way to follow it.
+// bump, and the bar has no way to follow it. The bar's own fade is keyed on the route, which flips
+// only when a pop commits, so it plays after a back gesture rather than during it — the destinations
+// are the half a held gesture seeks, which is why the alpha there is front-loaded.
 
 /**
  * How wide a screen's content is ever allowed to get.
@@ -280,8 +282,9 @@ fun YlihNavHost(
                 // so dropping the bar on `currentRoute` alone made it vanish a beat before the
                 // screen it belongs to had finished crossfading — and took its height with it,
                 // jerking the list underneath upwards mid-animation. AnimatedVisibility holds the
-                // height for the whole exit and hands it back at the start of the enter, so the two
-                // bars trade places in step with the destinations behind them. Tab-to-tab keeps the
+                // height until its own exit ends — which the shared spec puts at the moment the
+                // screen underneath has finished fading — and hands it back at the start of the
+                // enter, so the two bars trade places in step. Tab-to-tab keeps the
                 // bar untouched, which is the point of hoisting it here.
                 AnimatedVisibility(
                     visible = currentRoute != PAIR_ROUTE,

--- a/app/src/test/java/it/eldavo/ylih/ui/NavMotionTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/NavMotionTest.kt
@@ -15,8 +15,9 @@ import org.robolectric.annotation.Config
 
 /**
  * The spec every in-app navigation runs on. What is worth pinning is not the numbers themselves —
- * they are a judgement — but the two relations that stop the motion looking broken: that the scale
- * of a transition never outlives its fade, and that going back is the mirror of going in.
+ * they are a judgement — but the relations that stop the motion looking broken: that the alpha is
+ * finished before the scale is, that nothing outlives the motion, and that going back is the mirror
+ * of going in.
  *
  * A transition's own fields are internal to the animation library, so the shape is read back the
  * only way a caller can: by rebuilding the transition from a scale recovered out of its `toString`
@@ -28,6 +29,8 @@ import org.robolectric.annotation.Config
 class NavMotionTest {
 
     private val spec = tween<Float>(durationMillis = NAV_MOTION_MS)
+    private val out = tween<Float>(durationMillis = NAV_FADE_MS)
+    private val into = tween<Float>(durationMillis = NAV_FADE_MS, delayMillis = NAV_FADE_DELAY_MS)
 
     /** The scale factor a transition animates through, as it describes itself. */
     private fun scaleOf(transition: Any): Float {
@@ -39,28 +42,46 @@ class NavMotionTest {
 
     @Test
     fun `every navigation transition fades and scales on one spec`() {
-        // The failure this rules out is the one that was reported: a scale on a longer spec than
-        // the alpha, or with no alpha at all, ends with the screen still fully drawn and then gone.
+        // The failure this rules out is the one that was reported: a scale with no alpha at all, or
+        // an alpha put back on the full spec, ends with the screen still drawn and then simply gone.
         assertEquals(
             "forward enter",
-            fadeIn(spec) + scaleIn(spec, initialScale = scaleOf(navEnter())),
+            fadeIn(into) + scaleIn(spec, initialScale = scaleOf(navEnter())),
             navEnter(),
         )
         assertEquals(
             "forward exit",
-            fadeOut(spec) + scaleOut(spec, targetScale = scaleOf(navExit())),
+            fadeOut(out) + scaleOut(spec, targetScale = scaleOf(navExit())),
             navExit(),
         )
         assertEquals(
             "pop enter",
-            fadeIn(spec) + scaleIn(spec, initialScale = scaleOf(navPopEnter())),
+            fadeIn(into) + scaleIn(spec, initialScale = scaleOf(navPopEnter())),
             navPopEnter(),
         )
         assertEquals(
             "pop exit",
-            fadeOut(spec) + scaleOut(spec, targetScale = scaleOf(navPopExit())),
+            fadeOut(out) + scaleOut(spec, targetScale = scaleOf(navPopExit())),
             navPopExit(),
         )
+    }
+
+    @Test
+    fun `the fade is finished before the scale is`() {
+        // This is the #40 fix. A predictive-back gesture seeks the pop by finger progress instead of
+        // playing it, so an alpha spread over the whole timeline is still most of the way opaque
+        // where a real drag ends and the release has no duration left to fade it in — the page just
+        // vanishes. Front-loaded, it is already transparent by the time the gesture hands over.
+        assertTrue("alpha must end before the motion does", NAV_FADE_MS < NAV_MOTION_MS)
+        assertTrue("and it must still be a fade, not a cut", NAV_FADE_MS > 0)
+    }
+
+    @Test
+    fun `nothing outlives the motion`() {
+        // The arriving page's fade is delayed so the two screens are never both half-drawn over each
+        // other; delay plus fade is the duration exactly, so it stays inside the scale it rides on
+        // and a push and its pop remain the same length.
+        assertEquals(NAV_MOTION_MS, NAV_FADE_DELAY_MS + NAV_FADE_MS)
     }
 
     @Test
@@ -80,9 +101,10 @@ class NavMotionTest {
     @Test
     fun `the app bar fades on the same duration and does not scale`() {
         // It is outside the NavHost and faded by hand, so this is the only thing keeping it in step
-        // with the destinations. It stays scale-free on purpose — it has to hold its height.
-        assertEquals(fadeIn(spec), barEnter())
-        assertEquals(fadeOut(spec), barExit())
+        // with the destinations — including the front-loaded alpha, or the bar would still be
+        // fading over a page that had finished. It stays scale-free on purpose: it holds its height.
+        assertEquals(fadeIn(into), barEnter())
+        assertEquals(fadeOut(out), barExit())
     }
 
     private companion object {


### PR DESCRIPTION
#39 gave every navigation one motion, a scale and a fade on the same 700 ms tween, and that fixed the click. #40 is the other half of the same gesture: hold the back gesture, let go, and the page still leaves without a fade.

A predictive-back gesture does not play the pop, it seeks it — navigation-compose maps finger progress onto the transition's timeline. An alpha spread evenly over the whole 700 ms is therefore still nearly opaque wherever a real drag ends, and whatever the library does at the commit, animate the remainder or snap it, there is almost the entire fade left to dispose of in the time a release leaves. Those two endings look identical from the sofa and cannot be told apart without a phone, so the fix is aimed at the part that is true either way: the alpha, not the commit.

The fade is now front-loaded. The scale spends the full NAV_MOTION_MS; the alpha gets NAV_FADE_MS, a shorter tween that finishes inside it, and the arriving side gets the same tween delayed by the difference, so nothing outlives the motion and the two pages cross instead of both sitting at full alpha. A drag is most of the way transparent well before it reaches the edge. The click-back keeps the same duration and the same shape it has had since #39; only where the opacity sits inside it moves.

The app bar reads the same two specs, because it is not a destination and is faded by hand, and one spec read from both places is the whole reason NavMotion.kt is a file. It stays scale-free — it has to hold its height for the exit — and the shortened alpha means it now hands that height back at the moment the screen underneath has finished fading rather than three hundred milliseconds later. What the bar still cannot do is follow the finger: its fade is keyed on the route, which flips only when the pop commits, and the gesture is consumed by the NavHost's own PredictiveBackHandler, which offers no progress to anything outside it. Following it would mean owning the gesture and re-implementing the pop, which is more than the report asks for.

NavMotionTest pins this the way it already did — a transition's fields are internal to the animation library, so each one is rebuilt from the constants and from a scale recovered out of its toString and compared whole. The relation it asserted, that the scale never outlives its fade, becomes the stronger one the gesture needs: the fade ends before the scale does, and the delayed enter lands exactly on the end of the motion. The mirror test is unchanged, and YlihNavHostTest's halfway-through-the-pop geometry assertion is untouched and still proves the animation runs.

No strings, no dependencies, no schema.

Closes #40.

Closes #40.
