### PR TITLE
say the charge-cycle chart is still filling up rather than showing nothing

### DIFF
--- a/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
+++ b/app/src/main/java/it/eldavo/ylih/ui/PairDetailScreen.kt
@@ -435,6 +435,16 @@ private fun ChargeCyclesHeader(charge: ChargeSummary) {
                 firstLabel = stringResource(R.string.pair_cycle_number, 1),
                 lastLabel = stringResource(R.string.pair_cycle_number, charge.cycles.size),
             )
+        } else {
+            // Bound to the chart's own condition rather than to `versusNew == null`, which today
+            // is the same case: this line stands where the chart will stand, so what it promises
+            // has to arrive at the moment the chart does, whatever else changes about the tiles.
+            Spacer(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.pair_charge_calibrating),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">waargeneem</string>
     <string name="pair_vs_new">teenoor nuut</string>
     <string name="pair_cycle_number">siklus %1$d</string>
+    <string name="pair_charge_calibrating">luister verder om te sien hoe ’n lading verander</string>
     <string name="pair_rename_title">hernoem paar</string>
     <string name="pair_rename_label">naam</string>
     <string name="pair_retire_title">pensioneer hierdie paar</string>

--- a/app/src/main/res/values-ak/strings.xml
+++ b/app/src/main/res/values-ak/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">bere %d</item>
         <item quantity="other">bere %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">kɔ so tie na wobɛhunu sɛdeɛ ahoɔden sesa</string>
 </resources>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -194,4 +194,5 @@
         <item quantity="one">%d ስብሰባ</item>
         <item quantity="other">%d ስብሰባ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ማዳመጥዎን ይቀጥሉ፣ አንድ ሙሌት እንዴት እንደሚለወጥ ያያሉ</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -215,4 +215,5 @@
         <item quantity="many">%d جلسة</item>
         <item quantity="other">%d جلسة</item>
     </plurals>
+    <string name="pair_charge_calibrating">واصل الاستماع لترى كيف تتغيّر الشحنة</string>
 </resources>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d সেশন</item>
         <item quantity="other">%d সেশন</item>
     </plurals>
+    <string name="pair_charge_calibrating">শুনি থাকক আৰু চাওক এটা চাৰ্জ কেনেকৈ সলনি হয়</string>
 </resources>

--- a/app/src/main/res/values-b+agq/strings.xml
+++ b/app/src/main/res/values-b+agq/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">búŋ %d</item>
         <item quantity="other">búŋ %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">yúʼ ntsùŋ, wò ke yeŋ ǹdzə̀ sìkəl tsə̀ tsàŋ tsə̀ kaʼ</string>
 </resources>

--- a/app/src/main/res/values-b+ast/strings.xml
+++ b/app/src/main/res/values-b+ast/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">observao</string>
     <string name="pair_vs_new">frente a nueves</string>
     <string name="pair_cycle_number">ciclu %1$d</string>
+    <string name="pair_charge_calibrating">sigui escuchando pa ver cómo camuda una carga</string>
     <string name="pair_rename_title">renombrar par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">xubildar esta par</string>

--- a/app/src/main/res/values-b+az+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+az+Cyrl/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d сеанс</item>
         <item quantity="other">%d сеанс</item>
     </plurals>
+    <string name="pair_charge_calibrating">динләмәјә давам ет ки, бир енержи јығымынын неҹә дәјишдијини ҝөрәсән</string>
 </resources>

--- a/app/src/main/res/values-b+az+Latn/strings.xml
+++ b/app/src/main/res/values-b+az+Latn/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d seans</item>
         <item quantity="other">%d seans</item>
     </plurals>
+    <string name="pair_charge_calibrating">dinləməyə davam et ki, bir enerji yığımının necə dəyişdiyini görəsən</string>
 </resources>

--- a/app/src/main/res/values-b+bas/strings.xml
+++ b/app/src/main/res/values-b+bas/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">%d sɔŋ</item>
         <item quantity="other">%d sɔŋ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ke nɔgɔl, u ga tehe lelaa masikèl ma ŋgu ma nkeenge</string>
 </resources>

--- a/app/src/main/res/values-b+bem/strings.xml
+++ b/app/src/main/res/values-b+bem/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d fikapililo</item>
         <item quantity="other">%d ifikapililo</item>
     </plurals>
+    <string name="pair_charge_calibrating">twalilileni ukumfwa pa kuti mumone ifyo amaka yaaluka</string>
 </resources>

--- a/app/src/main/res/values-b+bho/strings.xml
+++ b/app/src/main/res/values-b+bho/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d सत्र</item>
         <item quantity="other">%d सत्र</item>
     </plurals>
+    <string name="pair_charge_calibrating">सुनत रहीं आ देखीं कि एगो चार्ज कइसे बदलेला</string>
 </resources>

--- a/app/src/main/res/values-b+blo/strings.xml
+++ b/app/src/main/res/values-b+blo/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="one">%d a ka ti</item>
         <item quantity="other">%d a ka ti</item>
     </plurals>
+    <string name="pair_charge_calibrating">yi si nu, a wu na ka sikili tɛ wu lɛbi</string>
 </resources>

--- a/app/src/main/res/values-b+bs+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+bs+Cyrl/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">посматрано</string>
     <string name="pair_vs_new">у односу на нове</string>
     <string name="pair_cycle_number">циклус %1$d</string>
+    <string name="pair_charge_calibrating">слушај даље да видиш како се пуњење мијења</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>
     <string name="pair_retire_title">повучи овај пар</string>

--- a/app/src/main/res/values-b+bs+Latn/strings.xml
+++ b/app/src/main/res/values-b+bs+Latn/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">posmatrano</string>
     <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
+    <string name="pair_charge_calibrating">slušaj dalje da vidiš kako se punjenje mijenja</string>
     <string name="pair_rename_title">preimenovaj paru</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">povuci ovu paru u penziju</string>

--- a/app/src/main/res/values-b+ceb/strings.xml
+++ b/app/src/main/res/values-b+ceb/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d ka session</item>
         <item quantity="other">%d ka session</item>
     </plurals>
+    <string name="pair_charge_calibrating">padayon sa pagpaminaw aron makita kon giunsa pagbag-o sa usa ka charge</string>
 </resources>

--- a/app/src/main/res/values-b+cgg/strings.xml
+++ b/app/src/main/res/values-b+cgg/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">okussozo %d</item>
         <item quantity="other">okussozo %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">gumizamu kuhurikiiza oreebe oku amaani gahindukira</string>
 </resources>

--- a/app/src/main/res/values-b+chr/strings.xml
+++ b/app/src/main/res/values-b+chr/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d ᎠᏟᏎᎵᏗ</item>
         <item quantity="other">%d ᎠᏟᏎᎵᏗ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ᏔᎵᏁ ᎯᏛᎬᏍᎨᏍᏗ ᎠᎴ ᎯᎪᏩᏛ ᎢᏳᏍᏗ ᎠᏓᏅᏬᏗ ᎦᏁᏟᏴᏍᎬᎢ</string>
 </resources>

--- a/app/src/main/res/values-b+csw/strings.xml
+++ b/app/src/main/res/values-b+csw/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d ᐊᑎᐦᒐᒧᐏᐣ</item>
         <item quantity="other">%d ᐊᑎᐦᒐᒧᕽᐊᓇ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ᐋᔭᒥᐦᑖ ᒥᓇ ᑭᐦᒋ ᐊᐧᐸᐦᑕᒪᐣ ᑖᓂᓯ ᐊᔅᑭᐦᐁᐧᐃᐣ ᐁ ᒣᔅᑲᒋᐸᔨᐠ</string>
 </resources>

--- a/app/src/main/res/values-b+dje/strings.xml
+++ b/app/src/main/res/values-b+dje/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">gasaandi %d</item>
         <item quantity="other">gasaandi %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">ma hangan koyne ka di gaabu ga bare mate</string>
 </resources>

--- a/app/src/main/res/values-b+dsb/strings.xml
+++ b/app/src/main/res/values-b+dsb/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">wobglědowane</string>
     <string name="pair_vs_new">napśeśiwo nowym</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
+    <string name="pair_charge_calibrating">słuchaj dalej, aby wiźeł, kak se nabiśe měnja</string>
     <string name="pair_rename_title">pśemjeniś paru</string>
     <string name="pair_rename_label">mě</string>
     <string name="pair_retire_title">toś tu paru pensioniriś</string>

--- a/app/src/main/res/values-b+dua/strings.xml
+++ b/app/src/main/res/values-b+dua/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">%d isela</item>
         <item quantity="other">%d isela</item>
     </plurals>
+    <string name="pair_charge_calibrating">tatane senga, o me je lambe ne masikèl ma ngiña ma mabelane</string>
 </resources>

--- a/app/src/main/res/values-b+dyo/strings.xml
+++ b/app/src/main/res/values-b+dyo/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">%d diñun</item>
         <item quantity="other">%d diñun</item>
     </plurals>
+    <string name="pair_charge_calibrating">kaanuŋ nabuŋ ba bu je nan sikili su kaarj sujaŋ</string>
 </resources>

--- a/app/src/main/res/values-b+ebu/strings.xml
+++ b/app/src/main/res/values-b+ebu/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">mahinda %d</item>
         <item quantity="other">mahinda %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">thĩkĩrĩria ũrĩ na mbere nĩguo wone ũrĩa inengi rĩgarũrũkaga</string>
 </resources>

--- a/app/src/main/res/values-b+ewo/strings.xml
+++ b/app/src/main/res/values-b+ewo/strings.xml
@@ -199,4 +199,5 @@
         <item quantity="many">dibulu %d</item>
         <item quantity="other">dibulu %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">vɔ́gɔ́ ai mvus, wa yen aval misikèl mi ngul mi kabɔ</string>
 </resources>

--- a/app/src/main/res/values-b+ff+Adlm/strings.xml
+++ b/app/src/main/res/values-b+ff+Adlm/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d 𞤶𞤮𞤳𞥆𞤮𞤤</item>
         <item quantity="other">%d 𞤶𞤮𞤳𞥆𞤮𞤤</item>
     </plurals>
+    <string name="pair_charge_calibrating">𞤶𞤮𞤳𞥆𞤵 𞤸𞤫𞤯𞤵𞤺𞤮𞤤 𞤲𞤺𞤢𞤥 𞤴𞤭𞤴𞤢𞥄 𞤲𞤮 𞤧𞤭𞤳𞤵𞤤𞤭 𞤳𞤢𞤪𞤶𞤢 𞤱𞤢𞤴𞤤𞤮𞤼𞤮𞥅</string>
 </resources>

--- a/app/src/main/res/values-b+ff+Latn/strings.xml
+++ b/app/src/main/res/values-b+ff+Latn/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d sekkuu</item>
         <item quantity="other">%d sekkuuji</item>
     </plurals>
+    <string name="pair_charge_calibrating">jokku heɗugol ngam yi’de no sikuli karja waylotoo</string>
 </resources>

--- a/app/src/main/res/values-b+fil/strings.xml
+++ b/app/src/main/res/values-b+fil/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d session</item>
         <item quantity="other">%d na session</item>
     </plurals>
+    <string name="pair_charge_calibrating">magpatuloy sa pakikinig para makita kung paano nagbabago ang isang charge</string>
 </resources>

--- a/app/src/main/res/values-b+fur/strings.xml
+++ b/app/src/main/res/values-b+fur/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservât</string>
     <string name="pair_vs_new">rispiet a gnûfs</string>
     <string name="pair_cycle_number">cicli %1$d</string>
+    <string name="pair_charge_calibrating">continue a scoltâ par viodi cemût che e cambie une cjarie</string>
     <string name="pair_rename_title">ribate non a cheste cuglia</string>
     <string name="pair_rename_label">non</string>
     <string name="pair_retire_title">pensionâ cheste cuglia</string>

--- a/app/src/main/res/values-b+gsw/strings.xml
+++ b/app/src/main/res/values-b+gsw/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">beobachtet</string>
     <string name="pair_vs_new">gägenüber neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">los wyter, zum gsee, wie sich e ladig verändert</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">dieses paar in rente</string>

--- a/app/src/main/res/values-b+guz/strings.xml
+++ b/app/src/main/res/values-b+guz/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">ichambire %d</item>
     </plurals>
     <string name="edit_failed">okoika omogendererwo gotachete</string>
+    <string name="pair_charge_calibrating">gwatia kogoka, orore buna amanga akoreka</string>
 </resources>

--- a/app/src/main/res/values-b+haw/strings.xml
+++ b/app/src/main/res/values-b+haw/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">nā hoʻomaka %d</item>
     </plurals>
     <string name="edit_failed">hiki ʻole ke mālama i ka hoʻololi</string>
+    <string name="pair_charge_calibrating">e hoʻomau i ka hoʻolohe i ʻike ʻoe i ka loli ʻana o ka hoʻopiha</string>
 </resources>

--- a/app/src/main/res/values-b+hi+Latn/strings.xml
+++ b/app/src/main/res/values-b+hi+Latn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d samvet</item>
     </plurals>
     <string name="edit_failed">badlaav save nahi ho saka</string>
+    <string name="pair_charge_calibrating">sunte rahiye aur dekhiye ki ek charge kaise badalta hai</string>
 </resources>

--- a/app/src/main/res/values-b+hsb/strings.xml
+++ b/app/src/main/res/values-b+hsb/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">wobkedźbowane</string>
     <string name="pair_vs_new">napřećo nowym</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
+    <string name="pair_charge_calibrating">słuchaj dale, zo by widźał, kak so nabiće měnja</string>
     <string name="pair_rename_title">paru přemjenować</string>
     <string name="pair_rename_label">mjeno</string>
     <string name="pair_retire_title">tutu paru zažywić</string>

--- a/app/src/main/res/values-b+jgo/strings.xml
+++ b/app/src/main/res/values-b+jgo/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">ntám %d</item>
     </plurals>
     <string name="edit_failed">kə́ nə́ tsə́ tsə́ʼ wə́</string>
+    <string name="pair_charge_calibrating">yúʼ pɔ́, ó zə́ yə̌n mbɛ́n sikǝl mǝ ntsɛ́ zə́ nzə</string>
 </resources>

--- a/app/src/main/res/values-b+kab/strings.xml
+++ b/app/src/main/res/values-b+kab/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d tirkutin</item>
     </plurals>
     <string name="edit_failed">ur yezmir ara ad isekles asnifel</string>
+    <string name="pair_charge_calibrating">kemmel asmuzget iwakken ad twaliḍ amek tettbeddil tewinest n uccetki</string>
 </resources>

--- a/app/src/main/res/values-b+kam/strings.xml
+++ b/app/src/main/res/values-b+kam/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d mulunde</item>
     </plurals>
     <string name="edit_failed">kwikĩa ũalyũku kwaema</string>
+    <string name="pair_charge_calibrating">endeea kwithukiisya nĩ kana wone ũndũ vinya ũkũalyũka</string>
 </resources>

--- a/app/src/main/res/values-b+kea/strings.xml
+++ b/app/src/main/res/values-b+kea/strings.xml
@@ -181,4 +181,5 @@
         <item quantity="other">%d sésõ</item>
     </plurals>
     <string name="edit_failed">ka konsigi salva mudansa</string>
+    <string name="pair_charge_calibrating">kontinua ta obi pa bu odja modi un karga ta muda</string>
 </resources>

--- a/app/src/main/res/values-b+kgp/strings.xml
+++ b/app/src/main/res/values-b+kgp/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d té</item>
     </plurals>
     <string name="edit_failed">tũ ki han mũ tũ</string>
+    <string name="pair_charge_calibrating">ẽ ke tugnĩn, jé ã kanhkã kar tỹ ke mũ ver</string>
 </resources>

--- a/app/src/main/res/values-b+khq/strings.xml
+++ b/app/src/main/res/values-b+khq/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d dunsee</item>
     </plurals>
     <string name="edit_failed">barmayyan mana gani</string>
+    <string name="pair_charge_calibrating">ma hangan koyne ka di gaabu ga bare mate</string>
 </resources>

--- a/app/src/main/res/values-b+kkj/strings.xml
+++ b/app/src/main/res/values-b+kkj/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d ndə fə</item>
     </plurals>
     <string name="edit_failed">pɛ mɛ nɛ bo</string>
+    <string name="pair_charge_calibrating">yúʼ ngɔ́, wo bɛ́ jɛ́nɛ ndé sikɛl mɛ ngbala mɛ tɔ́ŋgɔ</string>
 </resources>

--- a/app/src/main/res/values-b+kln/strings.xml
+++ b/app/src/main/res/values-b+kln/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d kotagit</item>
         <item quantity="other">%d kotagit</item>
     </plurals>
+    <string name="pair_charge_calibrating">yai kogeer ak kong’et si ige’e kolutik che kimnotin ko wale</string>
 </resources>

--- a/app/src/main/res/values-b+kok+Deva/strings.xml
+++ b/app/src/main/res/values-b+kok+Deva/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d सेशन</item>
     </plurals>
     <string name="edit_failed">बदल जतन करूंक जालो ना</string>
+    <string name="pair_charge_calibrating">आयकत रावा आनी पळय एक चार्ज कसो बदलता</string>
 </resources>

--- a/app/src/main/res/values-b+kok+Latn/strings.xml
+++ b/app/src/main/res/values-b+kok+Latn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d seshan</item>
     </plurals>
     <string name="edit_failed">badal jatan korunk zalo na</string>
+    <string name="pair_charge_calibrating">aikot ravat ani polloi ek charge koso bodolta</string>
 </resources>

--- a/app/src/main/res/values-b+ksf/strings.xml
+++ b/app/src/main/res/values-b+ksf/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d nkpoong</item>
     </plurals>
     <string name="edit_failed">á bɛ́ nde sá</string>
+    <string name="pair_charge_calibrating">wókii nyɔ, u yén lɛ́ sikɛl yé ndáá yé mbaŋ</string>
 </resources>

--- a/app/src/main/res/values-b+ksh/strings.xml
+++ b/app/src/main/res/values-b+ksh/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">beobaachtet</string>
     <string name="pair_vs_new">jäjenüver neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">hür wigger, öm ze sinn wie sesch en ladung verändert</string>
     <string name="pair_rename_title">paar ömbenenne</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">häm paar en rente</string>

--- a/app/src/main/res/values-b+ku+Latn/strings.xml
+++ b/app/src/main/res/values-b+ku+Latn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d danefînî</item>
     </plurals>
     <string name="edit_failed">guherîn nehat tomarkirin</string>
+    <string name="pair_charge_calibrating">guhdarî bike da ku bibînî çawa şarjek diguhere</string>
 </resources>

--- a/app/src/main/res/values-b+kxv+Deva/strings.xml
+++ b/app/src/main/res/values-b+kxv+Deva/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d सेसान</item>
     </plurals>
     <string name="edit_failed">आ बादाला साम्भाळा आ सिलि</string>
+    <string name="pair_charge_calibrating">विण्डिते मण्डु, चार्ज चक्र केत्ला मरुतेरि हिनि उड़ा</string>
 </resources>

--- a/app/src/main/res/values-b+kxv+Latn/strings.xml
+++ b/app/src/main/res/values-b+kxv+Latn/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d sesan</item>
         <item quantity="other">%d sesan</item>
     </plurals>
+    <string name="pair_charge_calibrating">vinḍite manḍu, charj chakra ketla maruteri hini uḍa</string>
 </resources>

--- a/app/src/main/res/values-b+kxv+Orya/strings.xml
+++ b/app/src/main/res/values-b+kxv+Orya/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d ସେସାନ</item>
         <item quantity="other">%d ସେସାନ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ୱିଣ୍ଡିତେ ମଣ୍ଡୁ, ଚାର୍ଜ ଚକ୍ର କେତ୍ଲା ମରୁତେରି ହିନି ଉଡ଼ା</string>
 </resources>

--- a/app/src/main/res/values-b+kxv+Telu/strings.xml
+++ b/app/src/main/res/values-b+kxv+Telu/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d సేసాన</item>
     </plurals>
     <string name="edit_failed">ఆ బాదాలా సామ్భాళా ఆ సిలి</string>
+    <string name="pair_charge_calibrating">విణ్డితే మణ్డు, చార్జ చక్ర కేత్లా మరుతేరి హిని ఉడా</string>
 </resources>

--- a/app/src/main/res/values-b+lij/strings.xml
+++ b/app/src/main/res/values-b+lij/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservou</string>
     <string name="pair_vs_new">rispetto a neuve</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">continua a sentî pe vedde comme a cangia ’na carega</string>
     <string name="pair_rename_title">cambya nome a-a pâriggia</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">ritira tia pâriggia</string>

--- a/app/src/main/res/values-b+lkt/strings.xml
+++ b/app/src/main/res/values-b+lkt/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">owótakhta %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">nayáȟʼuŋ yo, na wóiyokipȟaŋ kiŋ tókheča kiŋ waŋyáŋka nuŋwé</string>
 </resources>

--- a/app/src/main/res/values-b+lmo/strings.xml
+++ b/app/src/main/res/values-b+lmo/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservaa</string>
     <string name="pair_vs_new">respett a noeuv</string>
     <string name="pair_cycle_number">cicl %1$d</string>
+    <string name="pair_charge_calibrating">continua a scoltà per vedè come la cambia ’na carega</string>
     <string name="pair_rename_title">cambia nòm a la parea</string>
     <string name="pair_rename_label">nòm</string>
     <string name="pair_retire_title">messa via taa parea</string>

--- a/app/src/main/res/values-b+luo/strings.xml
+++ b/app/src/main/res/values-b+luo/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">kinde %d</item>
         <item quantity="other">kinde %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">dhi nyime winjo mondo ine kaka teko lokore</string>
 </resources>

--- a/app/src/main/res/values-b+luy/strings.xml
+++ b/app/src/main/res/values-b+luy/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">ebise %d</item>
         <item quantity="other">ebise %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">yendelela okhuwulila okhole olole shinga amaani kakalukhana</string>
 </resources>

--- a/app/src/main/res/values-b+mai/strings.xml
+++ b/app/src/main/res/values-b+mai/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d सत्र</item>
         <item quantity="other">%d सत्र</item>
     </plurals>
+    <string name="pair_charge_calibrating">सुनैत रहू आ देखू जे एक चार्ज कोना बदलैत अछि</string>
 </resources>

--- a/app/src/main/res/values-b+mas/strings.xml
+++ b/app/src/main/res/values-b+mas/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">enkata %d</item>
         <item quantity="other">inkata %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">ining’o aitoki, inyorrayie enkijape aitobirie</string>
 </resources>

--- a/app/src/main/res/values-b+mer/strings.xml
+++ b/app/src/main/res/values-b+mer/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">magita %d</item>
         <item quantity="other">magita %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">thikĩrĩria ũrĩ na mbere nĩguo wone ũrĩa inya rĩgarũrũkaga</string>
 </resources>

--- a/app/src/main/res/values-b+mfe/strings.xml
+++ b/app/src/main/res/values-b+mfe/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d sesion</item>
         <item quantity="other">%d sesion</item>
     </plurals>
+    <string name="pair_charge_calibrating">kontign ekoute pou to trouv kouma enn sarz sanze</string>
 </resources>

--- a/app/src/main/res/values-b+mgh/strings.xml
+++ b/app/src/main/res/values-b+mgh/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">ikathi %d</item>
         <item quantity="other">ikathi %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">ntthikelelaka wiriyana wira mmone moota inguvu sinivirela</string>
 </resources>

--- a/app/src/main/res/values-b+mgo/strings.xml
+++ b/app/src/main/res/values-b+mgo/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">nzə́ŋ %d</item>
         <item quantity="other">nzə́ŋ %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">yúʼ nə́ ntsə̀ʼ, ò zɨ́ yə̌n mbɛ́n sikəl mə ntsə mə nzə</string>
 </resources>

--- a/app/src/main/res/values-b+mni/strings.xml
+++ b/app/src/main/res/values-b+mni/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">সেসন %d</item>
         <item quantity="other">সেসন %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">ꯇꯥꯗꯨꯅꯥ ꯂꯩꯌꯨ ꯑꯃꯁꯨꯡ ꯆꯥꯔꯖ ꯑꯃꯅꯥ ꯀꯔꯝꯅꯥ ꯍꯣꯡꯏ ꯍꯥꯌꯕꯗꯨ ꯌꯦꯡꯉꯨ</string>
 </resources>

--- a/app/src/main/res/values-b+mzn/strings.xml
+++ b/app/src/main/res/values-b+mzn/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d جلسات</item>
         <item quantity="other">%d جلسات</item>
     </plurals>
+    <string name="pair_charge_calibrating">گوش هاکردن ره ادامه هاده تا بوینی شارژ چتی عوض وونه</string>
 </resources>

--- a/app/src/main/res/values-b+naq/strings.xml
+++ b/app/src/main/res/values-b+naq/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="two">%d ǃares</item>
         <item quantity="other">%d ǃares</item>
     </plurals>
+    <string name="pair_charge_calibrating">ǃaruǀî ǁnâu re, ǀgâuǃnâb mâti ra ǀkharaǀkharasen ǃkhaisa mû</string>
 </resources>

--- a/app/src/main/res/values-b+nds/strings.xml
+++ b/app/src/main/res/values-b+nds/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">beobacht</string>
     <string name="pair_vs_new">gegen nieg</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">hör wieder to, üm to sehn wo sik een ladung ännert</string>
     <string name="pair_rename_title">paar ander nomen geven</string>
     <string name="pair_rename_label">nomen</string>
     <string name="pair_retire_title">dit paar pensioneren</string>

--- a/app/src/main/res/values-b+nnh/strings.xml
+++ b/app/src/main/res/values-b+nnh/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d kə</item>
         <item quantity="other">%d kə</item>
     </plurals>
+    <string name="pair_charge_calibrating">yúʼ ntsé, ó bɛ́ yɛ́n mbé sikɛl mfɔ́ ó nzé</string>
 </resources>

--- a/app/src/main/res/values-b+nqo/strings.xml
+++ b/app/src/main/res/values-b+nqo/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d ߓߊߊߙߊ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ߌ ߦߋ߫ ߕߏ߫ ߟߊߡߍ߲ߠߌ߲ ߠߊ߫ ߞߊ߬ ߦߋ߫ ߝߊ߲߬ߞߊ ߦߋ߫ ߦߟߍ߬ߡߊ߲߬ ߠߊ߫ ߢߊ ߡߍ߲</string>
 </resources>

--- a/app/src/main/res/values-b+pa+Arab/strings.xml
+++ b/app/src/main/res/values-b+pa+Arab/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d سیشن</item>
         <item quantity="other">%d سیشن</item>
     </plurals>
+    <string name="pair_charge_calibrating">سݨدے رہو تے ݙیکھو جو اک چارج کیویں بدلدا اے</string>
 </resources>

--- a/app/src/main/res/values-b+pa+Guru/strings.xml
+++ b/app/src/main/res/values-b+pa+Guru/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ਸੈਸ਼ਨ</item>
         <item quantity="other">%d ਸੈਸ਼ਨ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ਸੁਣਦੇ ਰਹੋ ਅਤੇ ਵੇਖੋ ਕਿ ਇੱਕ ਚਾਰਜ ਕਿਵੇਂ ਬਦਲਦਾ ਹੈ</string>
 </resources>

--- a/app/src/main/res/values-b+pcm/strings.xml
+++ b/app/src/main/res/values-b+pcm/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d session</item>
         <item quantity="other">%d sessions</item>
     </plurals>
+    <string name="pair_charge_calibrating">continue to dey listen make you see how one charge dey change</string>
 </resources>

--- a/app/src/main/res/values-b+prg/strings.xml
+++ b/app/src/main/res/values-b+prg/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">endirīts</string>
     <string name="pair_vs_new">prei nauns</string>
     <string name="pair_cycle_number">ciklas %1$d</string>
+    <string name="pair_charge_calibrating">klausi tālaimai, kai endirītun, kaigi laddāsnā mainisei</string>
     <string name="pair_rename_title">pervadinti pāra</string>
     <string name="pair_rename_label">vardas</string>
     <string name="pair_retire_title">pensėti tī pāra</string>

--- a/app/src/main/res/values-b+sah/strings.xml
+++ b/app/src/main/res/values-b+sah/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d сессия</item>
     </plurals>
+    <string name="pair_charge_calibrating">истэ туруҥ, биир зарядка хайдах уларыйарын көрүөҥ</string>
 </resources>

--- a/app/src/main/res/values-b+saq/strings.xml
+++ b/app/src/main/res/values-b+saq/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d a-karata</item>
         <item quantity="other">%d a-karata</item>
     </plurals>
+    <string name="pair_charge_calibrating">ining’o aitoki, inyorrayie nkere aitobirie</string>
 </resources>

--- a/app/src/main/res/values-b+sat/strings.xml
+++ b/app/src/main/res/values-b+sat/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="two">%d ᱥᱮᱥᱚᱱ</item>
         <item quantity="other">%d ᱥᱮᱥᱚᱱ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ᱟᱡᱚᱢ ᱛᱟᱦᱮᱸᱱ ᱢᱮ, ᱢᱤᱫ ᱪᱟᱨᱡᱽ ᱪᱮᱫ ᱞᱮᱠᱟᱛᱮ ᱵᱚᱫᱚᱞ ᱠᱟᱱᱟ ᱧᱮᱞ ᱢᱮ</string>
 </resources>

--- a/app/src/main/res/values-b+sbp/strings.xml
+++ b/app/src/main/res/values-b+sbp/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d kusava</item>
         <item quantity="other">%d kusava</item>
     </plurals>
+    <string name="pair_charge_calibrating">endelela kupulikisya kuti ulole ingufu ndavule sishanduka</string>
 </resources>

--- a/app/src/main/res/values-b+sd+Arab/strings.xml
+++ b/app/src/main/res/values-b+sd+Arab/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d سيشن</item>
         <item quantity="other">%d سيشنز</item>
     </plurals>
+    <string name="pair_charge_calibrating">ٻڌندا رهو ته ڏسو ته هڪ چارج ڪيئن بدلجي ٿو</string>
 </resources>

--- a/app/src/main/res/values-b+seh/strings.xml
+++ b/app/src/main/res/values-b+seh/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d gawo</item>
         <item quantity="other">%d magawo</item>
     </plurals>
+    <string name="pair_charge_calibrating">pitirizani kubvesera toera muone kuti mphambvu isacinja tani</string>
 </resources>

--- a/app/src/main/res/values-b+ses/strings.xml
+++ b/app/src/main/res/values-b+ses/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d timide</item>
     </plurals>
+    <string name="pair_charge_calibrating">ma hanga koyne ka di gaabu ga bare mate</string>
 </resources>

--- a/app/src/main/res/values-b+smn/strings.xml
+++ b/app/src/main/res/values-b+smn/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="two">%d sessions</item>
         <item quantity="other">%d sessions</item>
     </plurals>
+    <string name="pair_charge_calibrating">kuldâl viehis, te uáináh maht luâđâm nubástuvá</string>
 </resources>

--- a/app/src/main/res/values-b+sr+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+sr+Cyrl/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">посматрано</string>
     <string name="pair_vs_new">у односу на нове</string>
     <string name="pair_cycle_number">циклус %1$d</string>
+    <string name="pair_charge_calibrating">слушај и даље да видиш како се пуњење мења</string>
     <string name="pair_rename_title">преименуј пар</string>
     <string name="pair_rename_label">назив</string>
     <string name="pair_retire_title">пензионирај овај пар</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">posmatrano</string>
     <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
+    <string name="pair_charge_calibrating">slušaj i dalje da vidiš kako se punjenje menja</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">penzioniši ovaj par</string>

--- a/app/src/main/res/values-b+syr/strings.xml
+++ b/app/src/main/res/values-b+syr/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ܡܘܬܒܐ</item>
         <item quantity="other">%d ܡܘܬܒܐ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ܗܘܝ ܫܡܥ ܬܘܒ ܕܬܚܙܐ ܐܝܟܢܐ ܡܫܬܚܠܦܐ ܡܠܝܬܐ</string>
 </resources>

--- a/app/src/main/res/values-b+szl/strings.xml
+++ b/app/src/main/res/values-b+szl/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">ôbserwowane</string>
     <string name="pair_vs_new">w porōwnaniu z nowymi</string>
     <string name="pair_cycle_number">cykel %1$d</string>
+    <string name="pair_charge_calibrating">suchej dalij, coby uwidzieć, jak sie mynio ladowanie</string>
     <string name="pair_rename_title">przemianuj pora</string>
     <string name="pair_rename_label">miano</string>
     <string name="pair_retire_title">dej pynzyjo tymu pora</string>

--- a/app/src/main/res/values-b+teo/strings.xml
+++ b/app/src/main/res/values-b+teo/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">apak %d</item>
         <item quantity="other">apakio %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">kitupokinos ainingokin, kanu ijenu ai eyongete apedor</string>
 </resources>

--- a/app/src/main/res/values-b+twq/strings.xml
+++ b/app/src/main/res/values-b+twq/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d kaari</item>
         <item quantity="other">%d kaari</item>
     </plurals>
+    <string name="pair_charge_calibrating">ma hangan koyne ka di gaabu ga bare mate</string>
 </resources>

--- a/app/src/main/res/values-b+tzm/strings.xml
+++ b/app/src/main/res/values-b+tzm/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d tasrtiut</item>
         <item quantity="other">%d tasrtiutin</item>
     </plurals>
+    <string name="pair_charge_calibrating">kemmel ad tsslid akken ad tẓred amek tettbeddil twinest n uccenṭi</string>
 </resources>

--- a/app/src/main/res/values-b+uz+Arab/strings.xml
+++ b/app/src/main/res/values-b+uz+Arab/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d سیانس</item>
         <item quantity="other">%d سیانس</item>
     </plurals>
+    <string name="pair_charge_calibrating">تینگلشدە داوام ایتینگ، بیر ذریادنینگ قندی اوزگرگنی نی کورینگ</string>
 </resources>

--- a/app/src/main/res/values-b+uz+Cyrl/strings.xml
+++ b/app/src/main/res/values-b+uz+Cyrl/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d сеанс</item>
         <item quantity="other">%d сеансле</item>
     </plurals>
+    <string name="pair_charge_calibrating">тинглашда давом этинг, бир заряд қандай ўзгаришини кўрасиз</string>
 </resources>

--- a/app/src/main/res/values-b+uz+Latn/strings.xml
+++ b/app/src/main/res/values-b+uz+Latn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d seаns</item>
         <item quantity="other">%d seаnsle</item>
     </plurals>
+    <string name="pair_charge_calibrating">tinglashda davom eting, bir zaryad qanday o’zgarishini ko’rasiz</string>
 </resources>

--- a/app/src/main/res/values-b+vec/strings.xml
+++ b/app/src/main/res/values-b+vec/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservà</string>
     <string name="pair_vs_new">rispeto a nove</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">continua a scoltar par védar come che canbia na carga</string>
     <string name="pair_rename_title">rinomina la para</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">manda sto para in pensione</string>

--- a/app/src/main/res/values-b+wae/strings.xml
+++ b/app/src/main/res/values-b+wae/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">bschaut</string>
     <string name="pair_vs_new">gegenüber nöi</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">los wíter, zum gseh wie sich e ladig verändrot</string>
     <string name="pair_rename_title">paar umbenennen</string>
     <string name="pair_rename_label">noma</string>
     <string name="pair_retire_title">däs paar ischtellee</string>

--- a/app/src/main/res/values-b+xnr/strings.xml
+++ b/app/src/main/res/values-b+xnr/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d सत्र</item>
         <item quantity="other">%d सत्र</item>
     </plurals>
+    <string name="pair_charge_calibrating">सुणदे रैओ ते दिक्खो जे इक चार्ज किञा बदलदा ऐ</string>
 </resources>

--- a/app/src/main/res/values-b+xog/strings.xml
+++ b/app/src/main/res/values-b+xog/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d okukola</item>
         <item quantity="other">%d okukola</item>
     </plurals>
+    <string name="pair_charge_calibrating">weyongere okuwuliriza olabe engeri amaani gye gakyukamu</string>
 </resources>

--- a/app/src/main/res/values-b+yav/strings.xml
+++ b/app/src/main/res/values-b+yav/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d muanda</item>
         <item quantity="other">%d muanda</item>
     </plurals>
+    <string name="pair_charge_calibrating">wókii nyɔ́ɔ, u yén lɛ́ sikɛl mʉ́ ndáá mʉ́ mbaŋ</string>
 </resources>

--- a/app/src/main/res/values-b+yrl/strings.xml
+++ b/app/src/main/res/values-b+yrl/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d apigara</item>
         <item quantity="other">%d apigara</item>
     </plurals>
+    <string name="pair_charge_calibrating">reasenduri ne yuiri, remaã taá sikuru karrega umukameẽ</string>
 </resources>

--- a/app/src/main/res/values-b+yue+Hans/strings.xml
+++ b/app/src/main/res/values-b+yue+Hans/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d 个节段</item>
     </plurals>
+    <string name="pair_charge_calibrating">继续听落去，就睇到一次充电点样变</string>
 </resources>

--- a/app/src/main/res/values-b+yue+Hant/strings.xml
+++ b/app/src/main/res/values-b+yue+Hant/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d 個節段</item>
     </plurals>
+    <string name="pair_charge_calibrating">繼續聽落去，就睇到一次充電點樣變</string>
 </resources>

--- a/app/src/main/res/values-b+zgh/strings.xml
+++ b/app/src/main/res/values-b+zgh/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d ⵙⴳⴳⴰⵙⵏ</item>
         <item quantity="other">%d ⵙⴳⴳⴰⵙⵏ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ⴽⵎⵎⵍ ⴰⴷ ⵜⵙⵙⴼⵍⴷⴷ ⴰⴷ ⵜⵥⵔⴷ ⵎⴰⵎⵛ ⵜⵜⴱⴷⴷⴰⵍ ⵜⵡⵉⵏⴰⵙⵜ ⵏ ⵓⵛⴰⵔⵊⵉ</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -192,4 +192,5 @@
     <plurals name="session_count">
         <item quantity="other">%d 次连接</item>
     </plurals>
+    <string name="pair_charge_calibrating">继续使用，就能看到一次充电的变化</string>
 </resources>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -193,4 +193,5 @@
     <plurals name="session_count">
         <item quantity="other">%d 次連線</item>
     </plurals>
+    <string name="pair_charge_calibrating">繼續使用，就能看到一次充電的變化</string>
 </resources>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">адсочана</string>
     <string name="pair_vs_new">у параўнанні з новымі</string>
     <string name="pair_cycle_number">цыкл %1$d</string>
+    <string name="pair_charge_calibrating">слухайце далей, каб убачыць, як мяняецца зарад</string>
     <string name="pair_rename_title">перайменаваць пару</string>
     <string name="pair_rename_label">імя</string>
     <string name="pair_retire_title">выключыце гэту пару</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">наблюдавано</string>
     <string name="pair_vs_new">спрямо нови</string>
     <string name="pair_cycle_number">цикъл %1$d</string>
+    <string name="pair_charge_calibrating">слушайте още, за да видите как се променя едно зареждане</string>
     <string name="pair_rename_title">преименуване на двойка</string>
     <string name="pair_rename_label">име</string>
     <string name="pair_retire_title">пенсионирайте тази двойка</string>

--- a/app/src/main/res/values-bm/strings.xml
+++ b/app/src/main/res/values-bm/strings.xml
@@ -191,4 +191,5 @@
     <plurals name="session_count">
         <item quantity="other">jiginna sutu %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">tila ka lamɛnni kɛ walasa ka fanga siklo yɛlɛmani ye</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d সেশন</item>
         <item quantity="other">%d সেশন</item>
     </plurals>
+    <string name="pair_charge_calibrating">শুনতে থাকুন, দেখুন একটি চার্জ কীভাবে বদলায়</string>
 </resources>

--- a/app/src/main/res/values-bo/strings.xml
+++ b/app/src/main/res/values-bo/strings.xml
@@ -191,4 +191,5 @@
     <plurals name="session_count">
         <item quantity="other">%d དུས་དྭངས་</item>
     </plurals>
+    <string name="pair_charge_calibrating">མུ་མཐུད་ནས་ཉོན་ན། གློག་ཚད་གཅིག་ཇི་ལྟར་འགྱུར་བ་མཐོང་ཐུབ</string>
 </resources>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">evezhiet</string>
     <string name="pair_vs_new">e-keñver nevez</string>
     <string name="pair_cycle_number">kelc’hiad %1$d</string>
+    <string name="pair_charge_calibrating">dalc’h da selaou evit gwelet penaos e cheñch ur c’harg</string>
     <string name="pair_rename_title">adenvel ur parol</string>
     <string name="pair_rename_label">anv</string>
     <string name="pair_retire_title">digemer ar parol-mañ</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -102,6 +102,7 @@
     <string name="pair_charge_watched">observat</string>
     <string name="pair_vs_new">respecte a nous</string>
     <string name="pair_cycle_number">cicle %1$d</string>
+    <string name="pair_charge_calibrating">continua escoltant per veure com canvia una càrrega</string>
     <string name="pair_rename_title">canviar nom del parell</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">jubilar aquest parell</string>

--- a/app/src/main/res/values-ce/strings.xml
+++ b/app/src/main/res/values-ce/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d сессия</item>
         <item quantity="other">%d сессияр</item>
     </plurals>
+    <string name="pair_charge_calibrating">ладогӀа тӀаьхьа а, заряд муха хийцало гуш</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">sledováno</string>
     <string name="pair_vs_new">oproti novým</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
+    <string name="pair_charge_calibrating">poslouchej dál a uvidíš, jak se nabití mění</string>
     <string name="pair_rename_title">přejmenovat pár</string>
     <string name="pair_rename_label">název</string>
     <string name="pair_retire_title">vyřadit tento pár</string>

--- a/app/src/main/res/values-cv/strings.xml
+++ b/app/src/main/res/values-cv/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="one">%d сеанс</item>
         <item quantity="other">%d сеанс</item>
     </plurals>
+    <string name="pair_charge_calibrating">малалла итлӗр, зарядлани мӗнле улшӑннине куратӑр</string>
 </resources>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">wedi’i wylio</string>
     <string name="pair_vs_new">o’i gymharu â newydd</string>
     <string name="pair_cycle_number">cylch %1$d</string>
+    <string name="pair_charge_calibrating">dal ati i wrando i weld sut mae gwefr yn newid</string>
     <string name="pair_rename_title">ailenwi pâr</string>
     <string name="pair_rename_label">enw</string>
     <string name="pair_retire_title">tynnu’r pâr hwn ymaith</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">observeret</string>
     <string name="pair_vs_new">mod da de var nye</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
+    <string name="pair_charge_calibrating">lyt videre for at se, hvordan en opladning ændrer sig</string>
     <string name="pair_rename_title">omdøb par</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">udfas dette par</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,6 +106,7 @@
     <string name="pair_charge_watched">beobachtet</string>
     <string name="pair_vs_new">gegenüber neu</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">hör weiter, um zu sehen, wie sich eine ladung verändert</string>
     <string name="pair_rename_title">Paar umbenennen</string>
     <string name="pair_rename_label">Name</string>
     <string name="pair_retire_title">dieses Paar ausmustern</string>

--- a/app/src/main/res/values-dz/strings.xml
+++ b/app/src/main/res/values-dz/strings.xml
@@ -194,4 +194,5 @@
     <plurals name="session_count">
         <item quantity="other">གླེང་སྟེགས་ %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">ཉན་བཞིན་སྡོད་གནང་། ཆརཇ་ཅིག་ག་དེ་སྦེ་འགྱུར་བ་མཐོང་འོང་</string>
 </resources>

--- a/app/src/main/res/values-ee/strings.xml
+++ b/app/src/main/res/values-ee/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d nusẽ</item>
         <item quantity="other">%d nusẽ wo</item>
     </plurals>
+    <string name="pair_charge_calibrating">yi edzi nàse eye nàkpɔ ale si ŋusẽdodo trɔna</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">παρακολουθήθηκε</string>
     <string name="pair_vs_new">έναντι καινούριων</string>
     <string name="pair_cycle_number">κύκλος %1$d</string>
+    <string name="pair_charge_calibrating">συνέχισε να ακούς για να δεις πώς αλλάζει μια φόρτιση</string>
     <string name="pair_rename_title">μετονομασία ζευγαριού</string>
     <string name="pair_rename_label">όνομα</string>
     <string name="pair_retire_title">απόσυρση αυτού του ζευγαριού</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">observita</string>
     <string name="pair_vs_new">kompare al nova</string>
     <string name="pair_cycle_number">ciklo %1$d</string>
+    <string name="pair_charge_calibrating">daŭre aŭskultu por vidi kiel ŝanĝiĝas ŝargo</string>
     <string name="pair_rename_title">renomi paron</string>
     <string name="pair_rename_label">nomo</string>
     <string name="pair_retire_title">pensigu ĉi tiun paron</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">observado</string>
     <string name="pair_vs_new">respecto a nuevos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">sigue escuchando para ver cómo cambia una carga</string>
     <string name="pair_rename_title">cambiar nombre del par</string>
     <string name="pair_rename_label">nombre</string>
     <string name="pair_retire_title">retirar este par</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">jälgitud</string>
     <string name="pair_vs_new">võrreldes uuega</string>
     <string name="pair_cycle_number">tsükkel %1$d</string>
+    <string name="pair_charge_calibrating">kuula edasi, et näha, kuidas laeng muutub</string>
     <string name="pair_rename_title">nimeta paar ümber</string>
     <string name="pair_rename_label">nimi</string>
     <string name="pair_retire_title">pensioneeri see paar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">behatuta</string>
     <string name="pair_vs_new">berri zirenekoaren aldean</string>
     <string name="pair_cycle_number">%1$d. zikloa</string>
+    <string name="pair_charge_calibrating">entzuten jarraitu karga baten iraupena nola aldatzen den ikusteko</string>
     <string name="pair_rename_title">pareza berrizendatu</string>
     <string name="pair_rename_label">izena</string>
     <string name="pair_retire_title">pare hau jubilatu</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -195,4 +195,5 @@
         <item quantity="one">%d جلسه</item>
         <item quantity="other">%d جلسه</item>
     </plurals>
+    <string name="pair_charge_calibrating">به شنیدن ادامه بده تا ببینی یک شارژ چطور تغییر می‌کند</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">seurattu</string>
     <string name="pair_vs_new">uutena verrattuna</string>
     <string name="pair_cycle_number">sykli %1$d</string>
+    <string name="pair_charge_calibrating">kuuntele lisää, niin näet miten lataus muuttuu</string>
     <string name="pair_rename_title">nimeä pari uudelleen</string>
     <string name="pair_rename_label">nimi</string>
     <string name="pair_retire_title">poista tämä pari käytöstä</string>

--- a/app/src/main/res/values-fo/strings.xml
+++ b/app/src/main/res/values-fo/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">eftirhugt</string>
     <string name="pair_vs_new">mót nýggjum</string>
     <string name="pair_cycle_number">syklus %1$d</string>
+    <string name="pair_charge_calibrating">lurta víðari fyri at síggja, hvussu ein lating broytist</string>
     <string name="pair_rename_title">endurnefna pair</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">útfasa hesa pair</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">observé</string>
     <string name="pair_vs_new">par rapport au neuf</string>
     <string name="pair_cycle_number">cycle %1$d</string>
+    <string name="pair_charge_calibrating">continue d’écouter pour voir comment une charge évolue</string>
     <string name="pair_rename_title">renommer la paire</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">retirer cette paire</string>

--- a/app/src/main/res/values-fy/strings.xml
+++ b/app/src/main/res/values-fy/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">waarnommen</string>
     <string name="pair_vs_new">tsjin nij oer</string>
     <string name="pair_cycle_number">syklus %1$d</string>
+    <string name="pair_charge_calibrating">bliuw harkjen om te sjen hoe’t in lading feroaret</string>
     <string name="pair_rename_title">dit pear omneame</string>
     <string name="pair_rename_label">namme</string>
     <string name="pair_retire_title">dit pear ôfskied</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">faoi bhreathnú</string>
     <string name="pair_vs_new">i gcomparáid le nua</string>
     <string name="pair_cycle_number">timthriall %1$d</string>
+    <string name="pair_charge_calibrating">coinnigh ort ag éisteacht le feiceáil conas a athraíonn luchtú</string>
     <string name="pair_rename_title">athainmnigh péire</string>
     <string name="pair_rename_label">ainm</string>
     <string name="pair_retire_title">scoir an péire seo</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">fo shùil</string>
     <string name="pair_vs_new">an coimeas ri ùr</string>
     <string name="pair_cycle_number">cuairt %1$d</string>
+    <string name="pair_charge_calibrating">cùm ort ag èisteachd gus faicinn mar a dh’atharraicheas teàrrsadh</string>
     <string name="pair_rename_title">ath-ainm paidhir</string>
     <string name="pair_rename_label">ainm</string>
     <string name="pair_retire_title">air falbh an paidhir seo</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observado</string>
     <string name="pair_vs_new">fronte a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">segue escoitando para ver como cambia unha carga</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">xubilar este par</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d સત્રો</item>
     </plurals>
     <string name="edit_failed">ફેરફાર સાચવી શકાયો નથી</string>
+    <string name="pair_charge_calibrating">સાંભળતા રહો અને જુઓ કે એક ચાર્જ કેવી રીતે બદલાય છે</string>
 </resources>

--- a/app/src/main/res/values-gv/strings.xml
+++ b/app/src/main/res/values-gv/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">jeeaghit</string>
     <string name="pair_vs_new">noi rish noa</string>
     <string name="pair_cycle_number">cruinnagh %1$d</string>
+    <string name="pair_charge_calibrating">cum ort geaishtagh dy akin kys ta lhieeney caghlaa</string>
     <string name="pair_rename_title">cur ennym noa paart</string>
     <string name="pair_rename_label">ennym</string>
     <string name="pair_retire_title">shoh kiart er paart shoh</string>

--- a/app/src/main/res/values-ha/strings.xml
+++ b/app/src/main/res/values-ha/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">zaman %d</item>
     </plurals>
     <string name="edit_failed">ba a iya ajiye canjin ba</string>
+    <string name="pair_charge_calibrating">ci gaba da sauraro don ganin yadda caji ke canjawa</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -198,4 +198,5 @@
         <item quantity="one">%d सत्र</item>
         <item quantity="other">%d सत्र</item>
     </plurals>
+    <string name="pair_charge_calibrating">सुनते रहें और देखें कि एक चार्ज कैसे बदलता है</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">promatrano</string>
     <string name="pair_vs_new">u odnosu na nove</string>
     <string name="pair_cycle_number">ciklus %1$d</string>
+    <string name="pair_charge_calibrating">slušaj dalje da vidiš kako se punjenje mijenja</string>
     <string name="pair_rename_title">preimenujem par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">povuci ovaj par</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">megfigyelve</string>
     <string name="pair_vs_new">az újhoz képest</string>
     <string name="pair_cycle_number">%1$d. ciklus</string>
+    <string name="pair_charge_calibrating">hallgasd tovább, és látod, hogyan változik egy töltés</string>
     <string name="pair_rename_title">pár átnevezése</string>
     <string name="pair_rename_label">név</string>
     <string name="pair_retire_title">pár kivonása</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d սեսիա</item>
     </plurals>
     <string name="edit_failed">փոփոխությունը չհաջողվեց պահել</string>
+    <string name="pair_charge_calibrating">շարունակիր լսել՝ տեսնելու, թե ինչպես է փոխվում մեկ լիցքը</string>
 </resources>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observate</string>
     <string name="pair_vs_new">comparate a nove</string>
     <string name="pair_cycle_number">cyclo %1$d</string>
+    <string name="pair_charge_calibrating">continua a ascoltar pro vider como un carga cambia</string>
     <string name="pair_rename_title">renominar parea</string>
     <string name="pair_rename_label">nomine</string>
     <string name="pair_retire_title">retira iste parea</string>

--- a/app/src/main/res/values-ie/strings.xml
+++ b/app/src/main/res/values-ie/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observat</string>
     <string name="pair_vs_new">comparat a nov</string>
     <string name="pair_cycle_number">cicle %1$d</string>
+    <string name="pair_charge_calibrating">continua auscultar por vider quam un carga cambia</string>
     <string name="pair_rename_title">renoma par</string>
     <string name="pair_rename_label">nom</string>
     <string name="pair_retire_title">retire ti par</string>

--- a/app/src/main/res/values-ig/strings.xml
+++ b/app/src/main/res/values-ig/strings.xml
@@ -181,4 +181,5 @@
         <item quantity="other">%d oge omume</item>
     </plurals>
     <string name="edit_failed">enweghị ike ịchekwa mgbanwe ahụ</string>
+    <string name="pair_charge_calibrating">gaa n’ihu na-ege ntị ka ị hụ ka ijupụta si agbanwe</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -192,4 +192,5 @@
     <plurals name="session_count">
         <item quantity="other">%d sesi</item>
     </plurals>
+    <string name="pair_charge_calibrating">terus dengarkan untuk melihat bagaimana satu pengisian berubah</string>
 </resources>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">fylgst með</string>
     <string name="pair_vs_new">miðað við ný</string>
     <string name="pair_cycle_number">lota %1$d</string>
+    <string name="pair_charge_calibrating">haltu áfram að hlusta til að sjá hvernig hleðsla breytist</string>
     <string name="pair_rename_title">endurnefna par</string>
     <string name="pair_rename_label">nafn</string>
     <string name="pair_retire_title">starfslok fyrir þetta par</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">osservato</string>
     <string name="pair_vs_new">rispetto a nuove</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">continua ad ascoltare per vedere come cambia una carica</string>
     <string name="pair_rename_title">rinomina paio</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">ritira questo paio</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -201,4 +201,5 @@
         <item quantity="two">%d מפגשים</item>
         <item quantity="other">%d מפגשים</item>
     </plurals>
+    <string name="pair_charge_calibrating">המשיכו להאזין כדי לראות איך טעינה משתנה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -195,4 +195,5 @@
     <plurals name="session_count">
         <item quantity="other">%dセッション</item>
     </plurals>
+    <string name="pair_charge_calibrating">使い続けると、1回の充電がどう変わるかがわかります</string>
 </resources>

--- a/app/src/main/res/values-jv/strings.xml
+++ b/app/src/main/res/values-jv/strings.xml
@@ -181,4 +181,5 @@
         <item quantity="other">%d sesi</item>
     </plurals>
     <string name="edit_failed">owahan ora bisa disimpen</string>
+    <string name="pair_charge_calibrating">terusna ngrungokake kanggo ndeleng owahé siji isi daya</string>
 </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d სესიები</item>
     </plurals>
     <string name="edit_failed">ცვლილების შენახვა ვერ მოხერხდა</string>
+    <string name="pair_charge_calibrating">განაგრძე მოსმენა, რომ ნახო როგორ იცვლება ერთი დამუხტვა</string>
 </resources>

--- a/app/src/main/res/values-ki/strings.xml
+++ b/app/src/main/res/values-ki/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="other">%d ĩrĩa</item>
     </plurals>
     <string name="edit_failed">kũiga ũgarũrũku gũtiahotekire</string>
+    <string name="pair_charge_calibrating">thikĩrĩria ũrĩ na mbere nĩguo wone ũrĩa hinya ũgarũrũkaga</string>
 </resources>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d сеанс</item>
     </plurals>
     <string name="edit_failed">өзгеріс сақталмады</string>
+    <string name="pair_charge_calibrating">тыңдай беріңіз, бір зарядтың қалай өзгеретінін көресіз</string>
 </resources>

--- a/app/src/main/res/values-kl/strings.xml
+++ b/app/src/main/res/values-kl/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ilortariaq</item>
         <item quantity="other">%d ilortariaq</item>
     </plurals>
+    <string name="pair_charge_calibrating">tusarnaajuarit kaajallanneq qanoq allanngortartoq takusinnaaniassagakku</string>
 </resources>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d សម័យ</item>
     </plurals>
+    <string name="pair_charge_calibrating">បន្តស្តាប់ ដើម្បីមើលថាថ្មមួយសាកប្រែប្រួលយ៉ាងណា</string>
 </resources>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ಸೆಶನ್</item>
         <item quantity="other">%d ಸೆಶನ್</item>
     </plurals>
+    <string name="pair_charge_calibrating">ಕೇಳುತ್ತಿರಿ, ಒಂದು ಚಾರ್ಜ್ ಹೇಗೆ ಬದಲಾಗುತ್ತದೆ ಎಂದು ನೋಡಿ</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -192,4 +192,5 @@
     <plurals name="session_count">
         <item quantity="other">%d개 세션</item>
     </plurals>
+    <string name="pair_charge_calibrating">계속 들으면 한 번 충전이 어떻게 달라지는지 볼 수 있어요</string>
 </resources>

--- a/app/src/main/res/values-kw/strings.xml
+++ b/app/src/main/res/values-kw/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">mires</string>
     <string name="pair_vs_new">warbynn nowyth</string>
     <string name="pair_cycle_number">kylgh %1$d</string>
+    <string name="pair_charge_calibrating">pesyewgh goslowes rag gweles fatel omjunj karg</string>
     <string name="pair_rename_title">adnevra par</string>
     <string name="pair_rename_label">anow</string>
     <string name="pair_retire_title">kas-hevel par na</string>

--- a/app/src/main/res/values-ky/strings.xml
+++ b/app/src/main/res/values-ky/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="other">%d сеанс</item>
     </plurals>
     <string name="edit_failed">өзгөртүү сакталган жок</string>
+    <string name="pair_charge_calibrating">уга бериңиз, бир заряд кантип өзгөрөрүн көрөсүз</string>
 </resources>

--- a/app/src/main/res/values-lb/strings.xml
+++ b/app/src/main/res/values-lb/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">beobaacht</string>
     <string name="pair_vs_new">am Verglach mat nei</string>
     <string name="pair_cycle_number">zyklus %1$d</string>
+    <string name="pair_charge_calibrating">lauschter weider, fir ze gesinn wéi sech eng luedung ännert</string>
     <string name="pair_rename_title">paar ëmbenenne</string>
     <string name="pair_rename_label">non</string>
     <string name="pair_retire_title">dësen paar pensionéieren</string>

--- a/app/src/main/res/values-lg/strings.xml
+++ b/app/src/main/res/values-lg/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">mutendera %d</item>
         <item quantity="other">mutendera %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">weeyongere okuwuliriza olabe engeri amaanyi bwe gakyuka</string>
 </resources>

--- a/app/src/main/res/values-ln/strings.xml
+++ b/app/src/main/res/values-ln/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d bilakisi</item>
         <item quantity="other">%d bilakisi</item>
     </plurals>
+    <string name="pair_charge_calibrating">kobanda koyoka lisusu mpo omona ndenge kotondisa ebongwanaka</string>
 </resources>

--- a/app/src/main/res/values-lo/strings.xml
+++ b/app/src/main/res/values-lo/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d ເຊດຊັນ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ຟັງຕໍ່ໄປເພື່ອເບິ່ງວ່າການສາກໜຶ່ງເທື່ອປ່ຽນແປງແນວໃດ</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">stebėta</string>
     <string name="pair_vs_new">palyginti su naujomis</string>
     <string name="pair_cycle_number">ciklas %1$d</string>
+    <string name="pair_charge_calibrating">klausykis toliau, kad pamatytum, kaip keičiasi įkrovimas</string>
     <string name="pair_rename_title">pervadinti pora</string>
     <string name="pair_rename_label">vardas</string>
     <string name="pair_retire_title">pensija sia pora</string>

--- a/app/src/main/res/values-lu/strings.xml
+++ b/app/src/main/res/values-lu/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d musala</item>
         <item quantity="other">%d musala</item>
     </plurals>
+    <string name="pair_charge_calibrating">tungunuka kuteleja bwa kumona mushindu bukome budi bushintuluka</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">novērots</string>
     <string name="pair_vs_new">salīdzinot ar jaunām</string>
     <string name="pair_cycle_number">%1$d. cikls</string>
+    <string name="pair_charge_calibrating">klausies vēl, lai redzētu, kā mainās uzlāde</string>
     <string name="pair_rename_title">pārdēvēt pāri</string>
     <string name="pair_rename_label">nosaukums</string>
     <string name="pair_retire_title">nodot šo pāri pensijā</string>

--- a/app/src/main/res/values-mg/strings.xml
+++ b/app/src/main/res/values-mg/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">fotoana %d</item>
         <item quantity="other">fotoana %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">mihainoa hatrany mba hahitanao ny fiovan’ny fameno iray</string>
 </resources>

--- a/app/src/main/res/values-mi/strings.xml
+++ b/app/src/main/res/values-mi/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d wātū</item>
         <item quantity="other">%d wātū</item>
     </plurals>
+    <string name="pair_charge_calibrating">kia mau tonu te whakarongo kia kite koe i te panoni o tētahi whakakī</string>
 </resources>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">набљудувано</string>
     <string name="pair_vs_new">во однос на нови</string>
     <string name="pair_cycle_number">циклус %1$d</string>
+    <string name="pair_charge_calibrating">слушај понатаму за да видиш како се менува едно полнење</string>
     <string name="pair_rename_title">преименувај пар</string>
     <string name="pair_rename_label">име</string>
     <string name="pair_retire_title">пензионирај го овој пар</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d സെഷൻ</item>
         <item quantity="other">%d സെഷനുകൾ</item>
     </plurals>
+    <string name="pair_charge_calibrating">കേട്ടുകൊണ്ടിരിക്കൂ, ഒരു ചാർജ് എങ്ങനെ മാറുന്നു എന്ന് കാണാം</string>
 </resources>

--- a/app/src/main/res/values-mn/strings.xml
+++ b/app/src/main/res/values-mn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d хуралдаан</item>
         <item quantity="other">%d хуралдаан</item>
     </plurals>
+    <string name="pair_charge_calibrating">сонсоод байгаарай, нэг цэнэг хэрхэн өөрчлөгдөхийг харна</string>
 </resources>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d सत्र</item>
         <item quantity="other">%d सत्रं</item>
     </plurals>
+    <string name="pair_charge_calibrating">ऐकत राहा आणि पाहा एक चार्ज कसा बदलतो</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d sesi</item>
     </plurals>
+    <string name="pair_charge_calibrating">terus dengar untuk lihat bagaimana satu cas berubah</string>
 </resources>

--- a/app/src/main/res/values-mt/strings.xml
+++ b/app/src/main/res/values-mt/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservat</string>
     <string name="pair_vs_new">imqabbla ma’ ġodda</string>
     <string name="pair_cycle_number">ċiklu %1$d</string>
+    <string name="pair_charge_calibrating">kompli isma’ biex tara kif tinbidel iċ-ċarġ</string>
     <string name="pair_rename_title">isemmi l-par mill-ġdid</string>
     <string name="pair_rename_label">isem</string>
     <string name="pair_retire_title">ritira l-par din</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d အခွင်းအရောင်များ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ဆက်နားထောင်ပါ၊ အားသွင်းတစ်ကြိမ်ဘယ်လိုပြောင်းလဲသလဲ မြင်ရပါမယ်</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -106,6 +106,7 @@
     <string name="pair_charge_watched">observert</string>
     <string name="pair_vs_new">mot da de var nye</string>
     <string name="pair_cycle_number">syklus %1$d</string>
+    <string name="pair_charge_calibrating">hør videre for å se hvordan en lading endrer seg</string>
     <string name="pair_rename_title">gi paret nytt navn</string>
     <string name="pair_rename_label">navn</string>
     <string name="pair_retire_title">pensjonér dette paret</string>

--- a/app/src/main/res/values-nd/strings.xml
+++ b/app/src/main/res/values-nd/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d umsebenzi</item>
         <item quantity="other">%d umsebenzi</item>
     </plurals>
+    <string name="pair_charge_calibrating">qhubeka ulalele ubone ukuthi ukugcwalisa kutshintsha njani</string>
 </resources>

--- a/app/src/main/res/values-ne/strings.xml
+++ b/app/src/main/res/values-ne/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d सत्र</item>
         <item quantity="other">%d सत्रहरू</item>
     </plurals>
+    <string name="pair_charge_calibrating">सुन्दै गर्नुहोस् र हेर्नुहोस् एउटा चार्ज कसरी बदलिन्छ</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">waargenomen</string>
     <string name="pair_vs_new">ten opzichte van nieuw</string>
     <string name="pair_cycle_number">cyclus %1$d</string>
+    <string name="pair_charge_calibrating">blijf luisteren om te zien hoe een lading verandert</string>
     <string name="pair_rename_title">koptelefoon hernoemen</string>
     <string name="pair_rename_label">naam</string>
     <string name="pair_retire_title">deze koptelefoon pensioneren</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observert</string>
     <string name="pair_vs_new">mot då dei var nye</string>
     <string name="pair_cycle_number">syklus %1$d</string>
+    <string name="pair_charge_calibrating">høyr vidare for å sjå korleis ei lading endrar seg</string>
     <string name="pair_rename_title">endr namn på par</string>
     <string name="pair_rename_label">namn</string>
     <string name="pair_retire_title">pensjonere dette paret</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ସେସନ</item>
         <item quantity="other">%d ସେସନ</item>
     </plurals>
+    <string name="pair_charge_calibrating">ଶୁଣିବା ଜାରି ରଖନ୍ତୁ ଓ ଦେଖନ୍ତୁ ଗୋଟିଏ ଚାର୍ଜ କିପରି ବଦଳେ</string>
 </resources>

--- a/app/src/main/res/values-os/strings.xml
+++ b/app/src/main/res/values-os/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d сесси</item>
         <item quantity="other">%d сесси</item>
     </plurals>
+    <string name="pair_charge_calibrating">хъусын дарддæр дæр, æмæ фендзынæ, зарядбæттæн куыд ивы</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">zaobserwowano</string>
     <string name="pair_vs_new">wobec nowych</string>
     <string name="pair_cycle_number">cykl %1$d</string>
+    <string name="pair_charge_calibrating">słuchaj dalej, aby zobaczyć, jak zmienia się ładowanie</string>
     <string name="pair_rename_title">zmień nazwę pary</string>
     <string name="pair_rename_label">nazwa</string>
     <string name="pair_retire_title">wycofaj tę parę</string>

--- a/app/src/main/res/values-ps/strings.xml
+++ b/app/src/main/res/values-ps/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d جلسه</item>
         <item quantity="other">%d جلسې</item>
     </plurals>
+    <string name="pair_charge_calibrating">اورېدلو ته دوام ورکړه چې وګورې چارج څنګه بدلېږي</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">observado</string>
     <string name="pair_vs_new">em relação a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">continue ouvindo para ver como uma carga muda</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">aposentar este par</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observado</string>
     <string name="pair_vs_new">em relação a novos</string>
     <string name="pair_cycle_number">ciclo %1$d</string>
+    <string name="pair_charge_calibrating">continua a ouvir para veres como muda uma carga</string>
     <string name="pair_rename_title">renomear par</string>
     <string name="pair_rename_label">nome</string>
     <string name="pair_retire_title">aposentar este par</string>

--- a/app/src/main/res/values-qu/strings.xml
+++ b/app/src/main/res/values-qu/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d rimay</item>
         <item quantity="other">%d rimay</item>
     </plurals>
+    <string name="pair_charge_calibrating">uyarispa kachkay, hunt’achiy imayna tikrakusqanta rikunaykipaq</string>
 </resources>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">observà</string>
     <string name="pair_vs_new">en congual cun nov</string>
     <string name="pair_cycle_number">ciclus %1$d</string>
+    <string name="pair_charge_calibrating">tadla ad ascultar per vesair co ch’ina chargia sa mida</string>
     <string name="pair_rename_title">renumner pair</string>
     <string name="pair_rename_label">num</string>
     <string name="pair_retire_title">pensiunar questa pair</string>

--- a/app/src/main/res/values-rn/strings.xml
+++ b/app/src/main/res/values-rn/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d isiganiro</item>
         <item quantity="other">%d isiganiro</item>
     </plurals>
+    <string name="pair_charge_calibrating">bandanya kwumviriza kugira ubone ukuntu ingoga zihinduka</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">observat</string>
     <string name="pair_vs_new">față de noi</string>
     <string name="pair_cycle_number">ciclul %1$d</string>
+    <string name="pair_charge_calibrating">ascultă în continuare ca să vezi cum se schimbă o încărcare</string>
     <string name="pair_rename_title">redenumește perechea</string>
     <string name="pair_rename_label">nume</string>
     <string name="pair_retire_title">retrage această pereche</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -103,6 +103,7 @@
     <string name="pair_charge_watched">под наблюдением</string>
     <string name="pair_vs_new">по сравнению с новыми</string>
     <string name="pair_cycle_number">цикл %1$d</string>
+    <string name="pair_charge_calibrating">слушайте дальше, чтобы увидеть, как меняется заряд</string>
     <string name="pair_rename_title">переименовать пару</string>
     <string name="pair_rename_label">имя</string>
     <string name="pair_retire_title">списать эту пару</string>

--- a/app/src/main/res/values-rw/strings.xml
+++ b/app/src/main/res/values-rw/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d isiganiro</item>
         <item quantity="other">%d isiganiro</item>
     </plurals>
+    <string name="pair_charge_calibrating">komeza kumva kugira ngo urebe uko ingufu zihinduka</string>
 </resources>

--- a/app/src/main/res/values-sa/strings.xml
+++ b/app/src/main/res/values-sa/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d सत्राणि</item>
         <item quantity="other">%d सत्राणि</item>
     </plurals>
+    <string name="pair_charge_calibrating">श्रवणं कुरु, चार्जः कथं परिवर्तते इति पश्य</string>
 </resources>

--- a/app/src/main/res/values-sc/strings.xml
+++ b/app/src/main/res/values-sc/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">osservadu</string>
     <string name="pair_vs_new">in cunfrontu a nois</string>
     <string name="pair_cycle_number">tzìclu %1$d</string>
+    <string name="pair_charge_calibrating">sighi a ascurtare pro bìdere comente càmbiat una càrriga</string>
     <string name="pair_rename_title">bennomine para</string>
     <string name="pair_rename_label">nòmine</string>
     <string name="pair_retire_title">pensiona custa para</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="two">%d vahkka</item>
         <item quantity="other">%d vahkka</item>
     </plurals>
+    <string name="pair_charge_calibrating">guldal viidáseappot vai oainnát mo láddensyklus rievdá</string>
 </resources>

--- a/app/src/main/res/values-sg/strings.xml
+++ b/app/src/main/res/values-sg/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d gbalá</item>
     </plurals>
+    <string name="pair_charge_calibrating">ngbâa ti mä ti bâ tongana nyen sarze ayeke gbian</string>
 </resources>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d සැසිකරණ</item>
         <item quantity="other">%d සැසිකරණ</item>
     </plurals>
+    <string name="pair_charge_calibrating">දිගටම අහන්න, එක් චාජ් එකක් වෙනස් වන ආකාරය බලන්න</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">sledované</string>
     <string name="pair_vs_new">oproti novým</string>
     <string name="pair_cycle_number">cyklus %1$d</string>
+    <string name="pair_charge_calibrating">počúvaj ďalej a uvidíš, ako sa nabitie mení</string>
     <string name="pair_rename_title">premenovať pár</string>
     <string name="pair_rename_label">meno</string>
     <string name="pair_retire_title">vyradiť tento pár</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">opazovano</string>
     <string name="pair_vs_new">glede na nove</string>
     <string name="pair_cycle_number">cikel %1$d</string>
+    <string name="pair_charge_calibrating">poslušaj naprej in videl boš, kako se polnjenje spreminja</string>
     <string name="pair_rename_title">preimenuj par</string>
     <string name="pair_rename_label">ime</string>
     <string name="pair_retire_title">upokoji ta par</string>

--- a/app/src/main/res/values-sn/strings.xml
+++ b/app/src/main/res/values-sn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d mipikiso</item>
         <item quantity="other">%d mipikiso</item>
     </plurals>
+    <string name="pair_charge_calibrating">rambai muchiteerera kuti muone kuti simba rinochinja sei</string>
 </resources>

--- a/app/src/main/res/values-so/strings.xml
+++ b/app/src/main/res/values-so/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d socodka</item>
         <item quantity="other">%d socodka</item>
     </plurals>
+    <string name="pair_charge_calibrating">sii wad dhegeysiga si aad u aragto sida dallacaaddu u beddelanto</string>
 </resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -97,6 +97,7 @@
     <string name="pair_charge_watched">vëzhguar</string>
     <string name="pair_vs_new">krahasuar me të reja</string>
     <string name="pair_cycle_number">cikli %1$d</string>
+    <string name="pair_charge_calibrating">vazhdo të dëgjosh për të parë si ndryshon një karikim</string>
     <string name="pair_rename_title">riemëro palën</string>
     <string name="pair_rename_label">emri</string>
     <string name="pair_retire_title">pensionojeni këtë palë</string>

--- a/app/src/main/res/values-st/strings.xml
+++ b/app/src/main/res/values-st/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">seboka se %d</item>
         <item quantity="other">liboka tse %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">tsoela pele o mamela hore o bone kamoo ho tjhaja ho fetohang</string>
 </resources>

--- a/app/src/main/res/values-su/strings.xml
+++ b/app/src/main/res/values-su/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d sési</item>
     </plurals>
+    <string name="pair_charge_calibrating">teruskeun ngadangukeun pikeun ningali kumaha hiji eusian robah</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">observerat</string>
     <string name="pair_vs_new">mot när de var nya</string>
     <string name="pair_cycle_number">cykel %1$d</string>
+    <string name="pair_charge_calibrating">fortsätt lyssna för att se hur en laddning förändras</string>
     <string name="pair_rename_title">byt namn på par</string>
     <string name="pair_rename_label">namn</string>
     <string name="pair_retire_title">pensionera detta par</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">kipindi %d</item>
         <item quantity="other">vipindi %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">endelea kusikiliza ili uone jinsi chaji inavyobadilika</string>
 </resources>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d அமர்வு</item>
         <item quantity="other">%d அமர்வுகள்</item>
     </plurals>
+    <string name="pair_charge_calibrating">தொடர்ந்து கேளுங்கள், ஒரு சார்ஜ் எப்படி மாறுகிறது என்று பாருங்கள்</string>
 </resources>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d సెషన్</item>
         <item quantity="other">%d సెషన్‌లు</item>
     </plurals>
+    <string name="pair_charge_calibrating">వినడం కొనసాగించండి, ఒక ఛార్జ్ ఎలా మారుతుందో చూడండి</string>
 </resources>

--- a/app/src/main/res/values-tg/strings.xml
+++ b/app/src/main/res/values-tg/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d ҷаласа</item>
         <item quantity="other">%d ҷаласа</item>
     </plurals>
+    <string name="pair_charge_calibrating">гӯш карданро идома диҳед, то бинед заряд чӣ гуна тағйир меёбад</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -193,4 +193,5 @@
     <plurals name="session_count">
         <item quantity="other">%d ช่วงการใช้งาน</item>
     </plurals>
+    <string name="pair_charge_calibrating">ฟังต่อไปเพื่อดูว่าการชาร์จหนึ่งครั้งเปลี่ยนไปอย่างไร</string>
 </resources>

--- a/app/src/main/res/values-ti/strings.xml
+++ b/app/src/main/res/values-ti/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d ምስጅ</item>
         <item quantity="other">%d ምስጃት</item>
     </plurals>
+    <string name="pair_charge_calibrating">ምስማዕ ቀጽል፣ ሓደ ምምላእ ከመይ ከም ዝቕየር ክትርኢ ኢኻ</string>
 </resources>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d session</item>
         <item quantity="other">%d sessions</item>
     </plurals>
+    <string name="pair_charge_calibrating">diňlemegi dowam et, zarýadyň nähili üýtgeýändigini görersiň</string>
 </resources>

--- a/app/src/main/res/values-tn/strings.xml
+++ b/app/src/main/res/values-tn/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d khutshane</item>
         <item quantity="other">%d dikhutshane</item>
     </plurals>
+    <string name="pair_charge_calibrating">tswelela go reetsa gore o bone kafa go tjhaja go fetogang ka teng</string>
 </resources>

--- a/app/src/main/res/values-to/strings.xml
+++ b/app/src/main/res/values-to/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">tukituki %d</item>
     </plurals>
+    <string name="pair_charge_calibrating">hokohoko atu hoʻo fanongo ke ke sio ki he liliu ʻo ha fakafonu</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">gözlenen</string>
     <string name="pair_vs_new">yeniyken hâline göre</string>
     <string name="pair_cycle_number">döngü %1$d</string>
+    <string name="pair_charge_calibrating">bir şarjın nasıl değiştiğini görmek için dinlemeye devam et</string>
     <string name="pair_rename_title">çifti yeniden adlandır</string>
     <string name="pair_rename_label">ad</string>
     <string name="pair_retire_title">bu çifti emekliye ayır</string>

--- a/app/src/main/res/values-tt/strings.xml
+++ b/app/src/main/res/values-tt/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d сессия</item>
         <item quantity="other">%d сессия</item>
     </plurals>
+    <string name="pair_charge_calibrating">тыңлавыгызны дәвам итегез, зарядның ничек үзгәрүен күрерсез</string>
 </resources>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d سەئاي</item>
         <item quantity="other">%d سەئاي</item>
     </plurals>
+    <string name="pair_charge_calibrating">ئاڭلاشنى داۋاملاشتۇرۇڭ، بىر قۇۋۋەتنىڭ قانداق ئۆزگىرىدىغانلىقىنى كۆرىسىز</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -104,6 +104,7 @@
     <string name="pair_charge_watched">під наглядом</string>
     <string name="pair_vs_new">порівняно з новими</string>
     <string name="pair_cycle_number">цикл %1$d</string>
+    <string name="pair_charge_calibrating">слухайте далі, щоб побачити, як змінюється заряд</string>
     <string name="pair_rename_title">перейменувати пару</string>
     <string name="pair_rename_label">назва</string>
     <string name="pair_retire_title">списати цю пару</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d سیشن</item>
         <item quantity="other">%d سیشنز</item>
     </plurals>
+    <string name="pair_charge_calibrating">سنتے رہیں تاکہ دیکھ سکیں کہ ایک چارج کیسے بدلتا ہے</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -192,4 +192,5 @@
     <plurals name="session_count">
         <item quantity="other">%d phiên</item>
     </plurals>
+    <string name="pair_charge_calibrating">hãy nghe tiếp để thấy một lần sạc thay đổi thế nào</string>
 </resources>

--- a/app/src/main/res/values-wo/strings.xml
+++ b/app/src/main/res/values-wo/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d sikasiit</item>
     </plurals>
+    <string name="pair_charge_calibrating">wéy ci déggloo ngir gis naka la wërndalu sarse di soppiku</string>
 </resources>

--- a/app/src/main/res/values-xh/strings.xml
+++ b/app/src/main/res/values-xh/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">%d session</item>
         <item quantity="other">%d session</item>
     </plurals>
+    <string name="pair_charge_calibrating">qhubeka umamele ukuze ubone ukuba ukutshaja kutshintsha njani</string>
 </resources>

--- a/app/src/main/res/values-yo/strings.xml
+++ b/app/src/main/res/values-yo/strings.xml
@@ -181,4 +181,5 @@
     <plurals name="session_count">
         <item quantity="other">%d isèwa</item>
     </plurals>
+    <string name="pair_charge_calibrating">máa fetísílẹ̀ lọ láti rí bí gbígbà agbára ṣe ń yípadà</string>
 </resources>

--- a/app/src/main/res/values-za/strings.xml
+++ b/app/src/main/res/values-za/strings.xml
@@ -189,4 +189,5 @@
         <item quantity="many">%d seih</item>
         <item quantity="other">%d seih</item>
     </plurals>
+    <string name="pair_charge_calibrating">laebae dingqnyi bae ndaej raen baez cungdenh ndeu bienq baenzlawz</string>
 </resources>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -185,4 +185,5 @@
         <item quantity="one">iseshini engu-%d</item>
         <item quantity="other">amaseshini angu-%d</item>
     </plurals>
+    <string name="pair_charge_calibrating">qhubeka ulalele ukuze ubone ukuthi ukushaja kushintsha kanjani</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,9 @@
     <string name="pair_vs_new">vs when new</string>
     <!-- Names one cycle in the list and on the chart's axis: "cycle 1", "cycle 12". -->
     <string name="pair_cycle_number">cycle %1$d</string>
+    <!-- Stands where the charge-cycle chart will stand, until two cycles have completed and there
+         is something to compare. "a charge" is one full hundred points of battery. -->
+    <string name="pair_charge_calibrating">keep listening to see how a charge changes</string>
     <string name="pair_rename_title">rename pair</string>
     <string name="pair_rename_label">name</string>
     <string name="pair_retire_title">retire this pair</string>

--- a/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
+++ b/app/src/test/java/it/eldavo/ylih/ui/PairDetailScreenTest.kt
@@ -235,6 +235,60 @@ class PairDetailScreenTest {
             "the whole list was searched and there is no charge section in it",
             runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isFailure,
         )
+        // Not even the "keep listening" line: a pair that will never report a level would carry it
+        // for ever, which is the permanent apology the absent section exists to avoid.
+        assertTrue(
+            "the whole list was searched and the calibrating note is not in it",
+            runCatching { scrollTo(text(R.string.pair_charge_calibrating)) }.isFailure,
+        )
+    }
+
+    /**
+     * A headset that reports its battery but has not yet drained a hundred points has the tiles and
+     * no chart, since a series of one bar says nothing. The line says what fills the gap.
+     */
+    @Test
+    fun `a pair still on its first charge cycle says so instead of drawing a chart`() {
+        val pairId = seedPair()
+        runBlocking {
+            val session = db.sessionDao().getAll().first()
+            fun reading(at: Long, level: Int) = runBlocking {
+                db.batterySampleDao().insert(
+                    BatterySampleEntity(
+                        sessionId = session.id,
+                        pairId = pairId,
+                        at = at,
+                        level = level,
+                    ),
+                )
+            }
+            reading(now - 3 * day, 100)
+            reading(now - 3 * day + 4 * hour, 40)
+        }
+
+        show(pairId)
+        compose.waitUntil(timeoutMillis = 10_000) {
+            runCatching { scrollTo(text(R.string.pair_charge_calibrating)) }.isSuccess
+        }
+
+        // The section itself is there, tiles and all — the note replaces the chart, not the figures.
+        scrollTo(text(R.string.pair_charge_cycles))
+    }
+
+    @Test
+    fun `the calibrating note goes once there are cycles to compare`() {
+        val pairId = seedPair()
+        seedBatteryReadings()
+
+        show(pairId)
+        compose.waitUntil(timeoutMillis = 10_000) {
+            runCatching { scrollTo(text(R.string.pair_charge_cycles)) }.isSuccess
+        }
+
+        assertTrue(
+            "the whole list was searched and the calibrating note is not in it",
+            runCatching { scrollTo(text(R.string.pair_charge_calibrating)) }.isFailure,
+        )
     }
 
     /** One session per cycle, a hundred points each, so [count] cycles complete. */


### PR DESCRIPTION
A pair whose headphones report their battery gets the charge-cycle section as soon as the first
point of drain is observed, but the chart under the tiles only appears once two cycles have
completed — a fortnight or more of ordinary use. Until then the section ended after four figures
with nothing to say that more was coming, so a new user had no way to learn the battery-health
curve exists, let alone that continuing to use the pair is what draws it.

The note is bound to the chart's own condition, `cycles.size <= 1`, as the else of the branch that
draws the chart, rather than to `versusNew == null`. The two coincide today; writing them as one
branch is what stops the promise and its fulfilment drifting apart later, and puts the line
exactly where the chart will stand.

It stays inside the `hasData` guard on purpose. A battery level reaches Android only over HFP,
Apple's vendor command or BLE's battery service, and plenty of headsets speak none of them; a note
on a pair that has never reported a level would be a permanent apology promising a feature those
headphones can never supply. The existing test that a silent pair has no charge section now also
asserts the note is absent, so the line cannot leak into that case.

Three tests cover the three states — readings but no completed cycle, two completed cycles, and no
readings at all. They assert by scrolling the whole list rather than by node absence, since a lazy
list composes only what is on screen and a bare "no such node" would pass for anything below the
fold.

The string is added to all 220 translated locales in the same commit, as MissingTranslation with no
baseline requires, and is referenced immediately so UnusedResources stays satisfied. No query, no
view-model change, no schema change and no new dependency.

Closes #43.


Closes #43.
